### PR TITLE
참가자 페이지 레이아웃 및 기능 개발

### DIFF
--- a/.cursor/rules/figma/convert.mdc
+++ b/.cursor/rules/figma/convert.mdc
@@ -1,0 +1,339 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+
+# Figma XML to Next.js + TypeScript + Tailwind 변환 완전 가이드
+
+## 핵심 원칙
+
+**절대 임의 판단하지 말 것. XML에 명시된 정보만 사용할 것.**
+
+## 1. 컴포넌트 판단 규칙
+
+### type="INSTANCE" 확인
+
+XML에서 type="INSTANCE"가 있으면 무조건 공통 컴포넌트를 고려하기
+
+- 공통 컴포넌트는 @shared/design/src/components에 명시된 컴포넌트를 사용해야 함
+- 없을 시 임시로 html 태그 + className을 통해 생성
+- import경로 체크 필수
+
+primaryBoxButton type="INSTANCE" → PrimaryBoxButton 컴포넌트 사용
+navigation type="INSTANCE" → Navigation 컴포넌트 사용
+
+### 컴포넌트명 변환 규칙
+
+XML 태그명을 PascalCase로 변환
+
+- navigation → Navigation
+- primaryBoxButton → PrimaryBoxButton
+- secondaryPlainIconButton → SecondaryPlainIconButton
+- sidepanelList_player_default_false → SidepanelListPlayer
+- playerStatus → PlayerStatus
+- input → Input
+- destructiveSolidIconButton → DestructiveSolidIconButton
+- secondaryGhostIconButton → SecondaryGhostIconButton
+
+### 컴포넌트 props 추출
+
+componentProperties 섹션에서 props 추출
+
+componentProperties
+size type="VARIANT" value="xl"
+style type="VARIANT" value="solid"
+state type="VARIANT" value="default"
+→ size="xl" style="solid" state="default"
+
+### 아이콘 컴포넌트 판단
+
+아이콘 이름으로 된 태그는 아이콘 컴포넌트
+
+Add id="I615:6029;1087:9961;1084:8300" → Add 컴포넌트
+Cross → Cross 컴포넌트
+Trash → Trash 컴포넌트
+
+### 일반 HTML 태그 판단
+
+type="INSTANCE"가 없고 Frame, Text 등은 일반 HTML
+
+Frame → div
+Text → span 또는 p
+
+### 완전한 컴포넌트 변환 예시
+
+XML 입력:
+primaryBoxButton id="615:6038" type="INSTANCE" cornerRadius="12"
+componentProperties
+size type="VARIANT" value="xl"
+style type="VARIANT" value="solid"
+state type="VARIANT" value="default"
+Text characters="참가자 및 팀 추가하기"
+
+변환 결과:
+PrimaryBoxButton
+size="xl"
+style="solid"
+state="default"
+className="rounded-[12px]"
+참가자 및 팀 추가하기
+
+### 중첩 컴포넌트 처리
+
+XML 입력:
+destructiveSolidIconButton type="INSTANCE"
+componentProperties
+size type="VARIANT" value="lg"
+state type="VARIANT" value="default"
+Trash
+
+변환 결과:
+DestructiveSolidIconButton
+size="lg"
+state="default"
+Trash
+
+## 2. Auto Layout 변환 규칙
+
+### layoutMode 변환
+
+layoutMode="VERTICAL" → flex flex-col
+layoutMode="HORIZONTAL" → flex flex-row  
+layoutMode="NONE" → relative
+
+### layoutSizing 변환
+
+layoutSizingHorizontal="FILL" → w-full
+layoutSizingHorizontal="FIXED" width="420" → w-[420px]
+layoutSizingHorizontal="HUG" → w-fit
+layoutSizingVertical="FILL" → h-full
+layoutSizingVertical="FIXED" height="110" → h-[110px]
+layoutSizingVertical="HUG" → h-fit
+
+### primaryAxisAlignItems 변환 (주축 정렬)
+
+layoutMode="HORIZONTAL" primaryAxisAlignItems="MIN" → flex flex-row justify-start
+layoutMode="HORIZONTAL" primaryAxisAlignItems="CENTER" → flex flex-row justify-center
+layoutMode="HORIZONTAL" primaryAxisAlignItems="MAX" → flex flex-row justify-end
+layoutMode="HORIZONTAL" primaryAxisAlignItems="SPACE_BETWEEN" → flex flex-row justify-between
+layoutMode="VERTICAL" primaryAxisAlignItems="CENTER" → flex flex-col items-center
+
+### counterAxisAlignItems 변환 (교차축 정렬)
+
+layoutMode="HORIZONTAL" counterAxisAlignItems="CENTER" → flex flex-row items-center
+layoutMode="HORIZONTAL" counterAxisAlignItems="MIN" → flex flex-row items-start
+layoutMode="HORIZONTAL" counterAxisAlignItems="MAX" → flex flex-row items-end
+layoutMode="VERTICAL" counterAxisAlignItems="CENTER" → flex flex-col justify-center
+
+### spacing과 padding 변환
+
+itemSpacing="24" → gap-[24px]
+itemSpacing="10" counterAxisSpacing="5" → gap-x-[10px] gap-y-[5px]
+paddingLeft="20" paddingRight="20" paddingTop="10" paddingBottom="10" → px-[20px] py-[10px]
+paddingLeft="40" paddingRight="40" paddingTop="0" paddingBottom="0" → px-[40px] py-0
+horizontalPadding="20" verticalPadding="15" → px-[20px] py-[15px]
+
+### layoutGrow 변환
+
+layoutGrow="1" → flex-grow
+layoutGrow="0" → flex-grow-0
+
+### layoutAlign 변환
+
+layoutAlign="STRETCH" → self-stretch
+layoutAlign="INHERIT" → (부모의 align 설정을 따름, 별도 클래스 불필요)
+
+## 3. 위치 지정 변환 (layoutMode="NONE"인 경우)
+
+### 절대 위치 지정
+
+layoutMode="NONE" Frame x="734" y="110" width="452" height="970"
+→
+div className="relative"
+div className="absolute left-[734px] top-[110px] w-[452px] h-[970px]"
+
+### constraints와 조합
+
+constraints horizontal="CENTER" vertical="MIN"
+→ absolute left-1/2 top-[110px] transform -translate-x-1/2
+
+## 4. 색상 변환 규칙
+
+### fills (배경색)
+
+fills fill type="SOLID" color="#ffffff" opacity="1" → bg-[#ffffff]
+fills fill type="SOLID" color="#51a2ff" opacity="0.5" → bg-[#51a2ff] bg-opacity-50
+
+### strokes (테두리)
+
+strokes stroke type="SOLID" color="#e5e7eb" opacity="1" strokeWeight="1" → border border-[#e5e7eb]
+strokeWeight="2" → border-2 border-[색상]
+
+### strokeAlign 변환
+
+strokeAlign="INSIDE" → border (기본값)
+strokeAlign="OUTSIDE" → outline outline-[두께] outline-[색상]
+strokeAlign="CENTER" → border (CSS에서 기본적으로 center)
+
+## 5. 모양 변환 규칙
+
+### cornerRadius
+
+cornerRadius="10" → rounded-[10px]
+cornerRadius="0" → rounded-none
+
+### cornerSmoothing (iOS 스타일)
+
+cornerSmoothing="0.6" → CSS custom property 또는 무시 (Tailwind 기본 지원 안함)
+
+## 6. 텍스트 스타일 변환 규칙
+
+### fontSize & fontWeight
+
+fontSize="28" fontWeight="600" fontName family="Pretendard" style="SemiBold"
+→ text-[28px] font-semibold font-['Pretendard']
+
+### textAlign
+
+textAlignHorizontal="CENTER" → text-center
+textAlignHorizontal="LEFT" → text-left
+textAlignVertical="TOP" → align-top
+
+### lineHeight
+
+lineHeight value="120.00000476837158" unit="PERCENT" → leading-[1.2]
+
+### letterSpacing
+
+letterSpacing value="0" unit="PERCENT" → tracking-normal
+
+### textCase
+
+textCase="ORIGINAL" → normal-case
+textCase="UPPER" → uppercase
+
+## 7. 효과 변환 규칙
+
+### opacity
+
+opacity="0.5" → opacity-50
+
+### blendMode
+
+blendMode="PASS_THROUGH" → (기본값, 별도 클래스 불필요)
+blendMode="MULTIPLY" → mix-blend-multiply
+
+### visible
+
+visible="false" → hidden
+visible="true" → (기본값, 별도 클래스 불필요)
+
+## 8. 특수 속성 변환
+
+### clipsContent
+
+clipsContent="true" → overflow-hidden
+clipsContent="false" → overflow-visible
+
+### isMask
+
+isMask="true" → CSS mask 속성 또는 clip-path 사용
+
+### rotation
+
+rotation="45" → rotate-[45deg]
+
+## 9. 그림자 효과
+
+### effects (그림자)
+
+effects effect type="DROP_SHADOW" color="#000000" opacity="0.1" offset="0,4" radius="8"
+→ shadow-[0_4px_8px_rgba(0,0,0,0.1)]
+
+## 10. 이미지/벡터 변환
+
+### Vector
+
+Vector strokeWeight="2" strokeJoin="ROUND" strokeCap="ROUND"
+→ SVG 컴포넌트로 변환하거나 아이콘 컴포넌트 사용
+
+### 이미지
+
+fills fill type="IMAGE" imageRef="image_id"
+→ bg-[url('/path/to/image.jpg')]
+
+## 11. import 경로
+
+### 컴포넌트 import
+
+import { Navigation, Input, PrimaryBoxButton } from '@ject-5-fe/design/components/\*';
+
+### 아이콘 import
+
+import { Add, Cross, Trash } from '@ject-5-fe/design/icons';
+
+## 12. 완전한 변환 예시
+
+### XML 입력
+
+Frame layoutMode="VERTICAL"
+layoutSizingHorizontal="FILL"
+layoutSizingVertical="FIXED" height="970"
+primaryAxisAlignItems="CENTER"
+counterAxisAlignItems="CENTER"
+itemSpacing="24"
+paddingLeft="35" paddingRight="35" paddingTop="25" paddingBottom="25"
+cornerRadius="10"
+clipsContent="false"
+fills
+fill type="SOLID" color="#f9fafb" opacity="1"
+strokes
+stroke type="SOLID" color="#e5e7eb" opacity="1"
+strokeWeight="1"
+
+### 올바른 변환
+
+div className="flex flex-col w-full h-[970px] items-center justify-center gap-[24px] px-[35px] py-[25px] rounded-[10px] overflow-visible bg-[#f9fafb] border border-[#e5e7eb]"
+
+## 13. 절대 금지 사항
+
+### 1. 색상 추측 변환 금지
+
+❌ color="#f9fafb" → bg-gray-50
+✅ color="#f9fafb" → bg-[#f9fafb]
+
+### 2. 크기 추측 변환 금지
+
+❌ width="64" → w-16
+✅ width="64" → w-[64px]
+
+### 3. 컴포넌트 props 임의 추가 금지
+
+❌ Input value={...} onChange={...}
+✅ Input type="reset" state="filled"
+
+### 4. type="INSTANCE" 없는데 컴포넌트로 만들기 금지
+
+❌ Frame → SomeComponent
+✅ Frame → div
+
+### 5. 텍스트 내용 임의 수정 금지
+
+Text characters="A팀가나다라마바사가나다라마바사"
+→ 정확히 A팀가나다라마바사가나다라마바사 사용
+
+## 14. 검증 체크리스트
+
+변환 후 반드시 확인:
+
+1. ✅ type="INSTANCE" 확인했는가?
+2. ✅ componentProperties의 모든 props 포함했는가?
+3. ✅ 모든 크기값이 XML과 정확히 일치하는가?
+4. ✅ 모든 색상값이 원본 hex값을 사용하는가?
+5. ✅ Auto Layout 속성들이 올바른 Flexbox로 변환되었는가?
+6. ✅ 텍스트 스타일이 정확한 값으로 변환되었는가?
+7. ✅ 추가된 props나 클래스가 모두 XML에 존재하는가?
+8. ✅ 임의로 변경된 부분이 없는가?
+
+**기억할 것: XML에 없는 정보는 절대 추가하지 말 것. 모든 값은 정확히 XML에 명시된 값만 사용할 것.**

--- a/service/app/src/app/game/[gameId]/components/index.tsx
+++ b/service/app/src/app/game/[gameId]/components/index.tsx
@@ -5,10 +5,13 @@ import {
   SecondaryGhostIconButton,
   SecondaryPlainIconButton,
 } from "@ject-5-fe/design/components/button"
+import { CustomDialog } from "@ject-5-fe/design/components/dialog"
 import * as InputComponents from "@ject-5-fe/design/components/input"
 import { PlayerStatus } from "@ject-5-fe/design/components/playerStatus"
 import { Cross, Sun } from "@ject-5-fe/design/icons"
 import { produce } from "immer"
+import Link from "next/link"
+import { useParams, useRouter } from "next/navigation"
 import { useState } from "react"
 
 interface Team {
@@ -35,13 +38,13 @@ const validateTeamName = (
   teams: Team[],
 ): string => {
   if (name.length === 0) {
-    return "팀명을 입력해주세요"
+    return "팀명을 비워둘 수 없어요."
   }
   if (name.length > MAX_TEAM_NAME_LENGTH) {
-    return "팀 이름이 너무 깁니다."
+    return "팀명은 30자까지만 가능해요."
   }
   if (teams.some((team) => team.id !== teamId && team.name === name)) {
-    return "중복된 팀 이름입니다."
+    return "이미 사용중인 팀명이에요."
   }
   return ""
 }
@@ -58,12 +61,15 @@ const updateTeamErrors = (teams: Team[]): { [teamId: string]: string } => {
 }
 
 export default function GameSetupPage() {
+  const params = useParams()
+  const router = useRouter()
   const [teamState, setTeamState] = useState<TeamState>(
     createTeamState([
       { id: "1", name: "A팀" },
       { id: "2", name: "B팀" },
     ]),
   )
+  const [isExitDialogOpen, setIsExitDialogOpen] = useState(false)
 
   const updateTeamName = (teamId: string, name: string) => {
     if (name.length > MAX_TEAM_NAME_LENGTH) {
@@ -108,37 +114,37 @@ export default function GameSetupPage() {
   return (
     <div className="flex h-screen w-screen flex-col bg-background-primary">
       {/* Navigation */}
-      <div className="flex h-[110px] w-full items-center justify-between bg-background-primary">
-        <div className="flex w-[420px] items-center gap-2.5 bg-background-tertiary px-10">
-          <div className="flex h-[60px] w-[268px] items-center justify-center">
-            <div className="size-8 bg-icon-interactive-primary" />
-          </div>
-        </div>
+      <div className="grid h-[110px] w-full grid-cols-[420px_1fr_420px] items-center bg-background-interactive-inverse px-10">
+        <div>로고</div>
 
-        <h1 className="typography-heading-lg-semibold text-text-primary">
+        <h1 className="typography-heading-lg-semibold whitespace-nowrap text-center text-text-primary">
           참가자 설정
         </h1>
 
-        <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+        <div className="flex flex-col items-end justify-center gap-2.5">
           <div className="flex items-center justify-end gap-4 px-10">
             <SecondaryGhostIconButton>
               <Sun />
             </SecondaryGhostIconButton>
-            <PrimaryBoxButton
-              size="sm"
-              _style="solid"
-              disabled={Object.keys(teamState.errors).length > 0}
+            <Link href={`/game/${params.gameId}/start`}>
+              <PrimaryBoxButton
+                size="sm"
+                _style="solid"
+                disabled={Object.keys(teamState.errors).length > 0}
+              >
+                게임 시작
+              </PrimaryBoxButton>
+            </Link>
+            <SecondaryPlainIconButton
+              size="lg"
+              onClick={() => setIsExitDialogOpen(true)}
             >
-              게임 시작
-            </PrimaryBoxButton>
-            <SecondaryPlainIconButton size="lg">
               <Cross />
             </SecondaryPlainIconButton>
           </div>
         </div>
       </div>
 
-      {/* Main Content */}
       <section className="flex flex-1 overflow-hidden">
         {/* Left Sidebar - Team List */}
         <div className="flex h-full w-[420px] flex-col gap-6 overflow-y-auto bg-background-tertiary px-[35px] pt-[25px]">
@@ -203,6 +209,20 @@ export default function GameSetupPage() {
           </div>
         </div>
       </section>
+
+      <CustomDialog
+        open={isExitDialogOpen}
+        onOpenChange={setIsExitDialogOpen}
+        title="게임을 나가시겠습니까?"
+        description="진행 중인 게임이 종료됩니다."
+        onConfirm={() => {
+          router.push("/")
+          setIsExitDialogOpen(false)
+        }}
+        onCancel={() => setIsExitDialogOpen(false)}
+        confirmText="나가기"
+        cancelText="취소"
+      />
     </div>
   )
 }

--- a/service/app/src/app/game/[gameId]/components/index.tsx
+++ b/service/app/src/app/game/[gameId]/components/index.tsx
@@ -94,7 +94,7 @@ export default function GameSetupPage() {
 
     setTeamState(
       produce((draft) => {
-        const newId = String(Date.now())
+        const newId = String(draft.teams.length + 1)
         const newTeamName = `${String.fromCharCode(65 + draft.teams.length)}팀`
         draft.teams.push({ id: newId, name: newTeamName })
         draft.errors = updateTeamErrors(draft.teams)
@@ -126,7 +126,7 @@ export default function GameSetupPage() {
             <SecondaryGhostIconButton>
               <Sun />
             </SecondaryGhostIconButton>
-            <Link href={`/game/${params.gameId}/start`}>
+            <Link href={`/game/${params.gameId}/play`}>
               <PrimaryBoxButton
                 size="sm"
                 _style="solid"
@@ -200,7 +200,6 @@ export default function GameSetupPage() {
               <PrimaryBoxButton
                 size="xl"
                 _style="solid"
-                // onClick={addTeam}
                 disabled={teamState.teams.length >= MAX_TEAMS}
               >
                 참가자 및 팀 추가하기

--- a/service/app/src/app/game/[gameId]/components/index.tsx
+++ b/service/app/src/app/game/[gameId]/components/index.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import {
+  PrimaryBoxButton,
+  SecondaryGhostIconButton,
+  SecondaryPlainIconButton,
+} from "@ject-5-fe/design/components/button"
+import * as InputComponents from "@ject-5-fe/design/components/input"
+import { PlayerStatus } from "@ject-5-fe/design/components/playerStatus"
+import { Cross, Sun } from "@ject-5-fe/design/icons"
+import { produce } from "immer"
+import { useState } from "react"
+
+interface Team {
+  id: string
+  name: string
+}
+
+interface TeamState {
+  teams: Team[]
+  errors: { [teamId: string]: string }
+}
+
+const MAX_TEAMS = 10
+const MAX_TEAM_NAME_LENGTH = 30
+
+const createTeamState = (initialTeams: Team[] = []): TeamState => ({
+  teams: initialTeams,
+  errors: {},
+})
+
+const validateTeamName = (
+  teamId: string,
+  name: string,
+  teams: Team[],
+): string => {
+  if (name.length === 0) {
+    return "팀명을 입력해주세요"
+  }
+  if (name.length > MAX_TEAM_NAME_LENGTH) {
+    return "팀 이름이 너무 깁니다."
+  }
+  if (teams.some((team) => team.id !== teamId && team.name === name)) {
+    return "중복된 팀 이름입니다."
+  }
+  return ""
+}
+
+const updateTeamErrors = (teams: Team[]): { [teamId: string]: string } => {
+  const errors: { [teamId: string]: string } = {}
+  teams.forEach((team) => {
+    const error = validateTeamName(team.id, team.name, teams)
+    if (error) {
+      errors[team.id] = error
+    }
+  })
+  return errors
+}
+
+export default function GameSetupPage() {
+  const [teamState, setTeamState] = useState<TeamState>(
+    createTeamState([
+      { id: "1", name: "A팀" },
+      { id: "2", name: "B팀" },
+    ]),
+  )
+
+  const updateTeamName = (teamId: string, name: string) => {
+    if (name.length > MAX_TEAM_NAME_LENGTH) {
+      return
+    }
+
+    setTeamState(
+      produce((draft) => {
+        const teamIndex = draft.teams.findIndex((team) => team.id === teamId)
+        if (teamIndex !== -1) {
+          draft.teams[teamIndex].name = name
+          draft.errors = updateTeamErrors(draft.teams)
+        }
+      }),
+    )
+  }
+
+  const addTeam = () => {
+    if (teamState.teams.length >= MAX_TEAMS) {
+      return
+    }
+
+    setTeamState(
+      produce((draft) => {
+        const newId = String(Date.now())
+        const newTeamName = `${String.fromCharCode(65 + draft.teams.length)}팀`
+        draft.teams.push({ id: newId, name: newTeamName })
+        draft.errors = updateTeamErrors(draft.teams)
+      }),
+    )
+  }
+
+  const removeTeam = (teamId: string) => {
+    setTeamState(
+      produce((draft) => {
+        draft.teams = draft.teams.filter((team) => team.id !== teamId)
+        draft.errors = updateTeamErrors(draft.teams)
+      }),
+    )
+  }
+
+  return (
+    <div className="flex h-screen w-screen flex-col bg-background-primary">
+      {/* Navigation */}
+      <div className="flex h-[110px] w-full items-center justify-between bg-background-primary">
+        <div className="flex w-[420px] items-center gap-2.5 bg-background-tertiary px-10">
+          <div className="flex h-[60px] w-[268px] items-center justify-center">
+            <div className="size-8 bg-icon-interactive-primary" />
+          </div>
+        </div>
+
+        <h1 className="typography-heading-lg-semibold text-text-primary">
+          참가자 설정
+        </h1>
+
+        <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+          <div className="flex items-center justify-end gap-4 px-10">
+            <SecondaryGhostIconButton>
+              <Sun />
+            </SecondaryGhostIconButton>
+            <PrimaryBoxButton
+              size="sm"
+              _style="solid"
+              disabled={Object.keys(teamState.errors).length > 0}
+            >
+              게임 시작
+            </PrimaryBoxButton>
+            <SecondaryPlainIconButton size="lg">
+              <Cross />
+            </SecondaryPlainIconButton>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <section className="flex flex-1 overflow-hidden">
+        {/* Left Sidebar - Team List */}
+        <div className="flex h-full w-[420px] flex-col gap-6 overflow-y-auto bg-background-tertiary px-[35px] pt-[25px]">
+          {teamState.teams.map((team) => (
+            <PlayerStatus
+              key={team.id}
+              name={team.name}
+              score=""
+              scoreView={false}
+              className="h-[118px]"
+            />
+          ))}
+        </div>
+
+        {/* Right Content - Team Management */}
+        <div className="flex h-full flex-1 flex-col items-center justify-center">
+          <div className="flex max-h-full min-w-[452px] flex-col items-center justify-start overflow-y-auto">
+            {/* Team Input Fields */}
+            <InputComponents.Root
+              className="flex w-full flex-col gap-6"
+              onSubmit={(e) => {
+                e.preventDefault()
+                addTeam()
+              }}
+            >
+              {teamState.teams.map((team) => (
+                <div key={team.id}>
+                  <InputComponents.Field
+                    name={`team-${team.id}`}
+                    type="reset"
+                    state={teamState.errors[team.id] ? "error" : "default"}
+                  >
+                    <InputComponents.Control
+                      value={team.name}
+                      onChange={(value) => updateTeamName(team.id, value)}
+                      onReset={() => {
+                        if (teamState.teams.length > 2) {
+                          removeTeam(team.id)
+                        }
+                      }}
+                      maxLength={MAX_TEAM_NAME_LENGTH}
+                      max={MAX_TEAM_NAME_LENGTH}
+                    />
+                    {teamState.errors[team.id] && (
+                      <InputComponents.ErrorText>
+                        {teamState.errors[team.id]}
+                      </InputComponents.ErrorText>
+                    )}
+                  </InputComponents.Field>
+                </div>
+              ))}
+              {/* Add Team Button */}
+              <PrimaryBoxButton
+                size="xl"
+                _style="solid"
+                // onClick={addTeam}
+                disabled={teamState.teams.length >= MAX_TEAMS}
+              >
+                참가자 및 팀 추가하기
+              </PrimaryBoxButton>
+            </InputComponents.Root>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/components/index.tsx
+++ b/service/app/src/app/game/[gameId]/components/index.tsx
@@ -215,8 +215,8 @@ export default function GameSetupPage() {
         title="게임을 나가시겠습니까?"
         description="진행 중인 게임이 종료됩니다."
         onConfirm={() => {
-          router.push("/")
           setIsExitDialogOpen(false)
+          router.push("/")
         }}
         onCancel={() => setIsExitDialogOpen(false)}
         confirmText="나가기"

--- a/service/app/src/app/game/[gameId]/layout.tsx
+++ b/service/app/src/app/game/[gameId]/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react"
+
+import { getGameDetail } from "@/entities/game/api/getGameDetail"
+
+import { GameStoreProvider } from "./store/useGameStore"
+
+export default async function GameLayout({
+  params,
+  children,
+}: {
+  params: { gameId: string }
+  children: ReactNode
+}) {
+  const gameDetail = await getGameDetail(params.gameId)
+  if (gameDetail.result === "ERROR" || !gameDetail.data) {
+    return <div>게임을 찾을 수 없습니다: {gameDetail.error?.message}</div>
+  }
+
+  return (
+    <GameStoreProvider initialGameDetail={gameDetail.data}>
+      {children}
+    </GameStoreProvider>
+  )
+}

--- a/service/app/src/app/game/[gameId]/page.tsx
+++ b/service/app/src/app/game/[gameId]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export default function GamePage({ params }: { params: { gameId: string } }) {
+  redirect(`/game/${params.gameId}/setup`)
+}

--- a/service/app/src/app/game/[gameId]/play/page.tsx
+++ b/service/app/src/app/game/[gameId]/play/page.tsx
@@ -1,0 +1,7 @@
+export default function GamePlayPage() {
+  return (
+    <div>
+      <h1>Game Play</h1>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/result/page.tsx
+++ b/service/app/src/app/game/[gameId]/result/page.tsx
@@ -1,0 +1,7 @@
+export default function GameResultPage() {
+  return (
+    <div>
+      <h1>Game Result</h1>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/setup/page.tsx
+++ b/service/app/src/app/game/[gameId]/setup/page.tsx
@@ -1,0 +1,5 @@
+import GameSetupPage from "../components"
+
+export default function SetupPage() {
+  return <GameSetupPage />
+}

--- a/service/app/src/app/game/[gameId]/store/useGameStore.tsx
+++ b/service/app/src/app/game/[gameId]/store/useGameStore.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import { produce } from "immer"
+import { createContext, type ReactNode, useContext, useRef } from "react"
+import { create, useStore } from "zustand"
+
+import type { GameDetailData } from "@/entities/game/model"
+
+export interface Team {
+  id: string
+  name: string
+  score: number
+  members: string[]
+}
+
+interface GameState {
+  gameDetail: GameDetailData | null
+
+  teams: Team[]
+  gameStatus: "setup" | "playing" | "paused" | "finished"
+  currentRound: number
+  totalRounds: number
+
+  settings: {
+    timeLimit?: number
+    maxTeams?: number
+  }
+}
+
+interface GameActions {
+  // 게임 초기화
+  setGameDetail: (gameDetail: GameDetailData) => void
+
+  // 팀 관리
+  addTeam: (team: Omit<Team, "score">) => void
+  removeTeam: (teamId: string) => void
+  updateTeamScore: (teamId: string, score: number) => void
+  addScoreToTeam: (teamId: string, points: number) => void
+
+  // 게임 진행
+  setGameStatus: (status: GameState["gameStatus"]) => void
+  nextRound: () => void
+  resetGame: () => void
+
+  // 설정
+  updateSettings: (settings: Partial<GameState["settings"]>) => void
+}
+
+const createGameStore = (initialGameDetail?: GameDetailData) =>
+  create<GameState & GameActions>((set) => ({
+    gameDetail: initialGameDetail || null,
+    teams: [],
+    gameStatus: "setup",
+    currentRound: 1,
+    totalRounds: 1,
+    settings: {},
+
+    // 액션들
+    setGameDetail: (gameDetail) => set({ gameDetail }),
+
+    addTeam: (team) =>
+      set(
+        produce((state: GameState) => {
+          state.teams.push({ ...team, score: 0 })
+        }),
+      ),
+
+    removeTeam: (teamId) =>
+      set(
+        produce((state: GameState) => {
+          const index = state.teams.findIndex(
+            (team: Team) => team.id === teamId,
+          )
+          if (index !== -1) {
+            state.teams.splice(index, 1)
+          }
+        }),
+      ),
+
+    updateTeamScore: (teamId, score) =>
+      set(
+        produce((state: GameState) => {
+          const team = state.teams.find((team: Team) => team.id === teamId)
+          if (team) {
+            team.score = score
+          }
+        }),
+      ),
+
+    addScoreToTeam: (teamId, points) =>
+      set(
+        produce((state: GameState) => {
+          const team = state.teams.find((team: Team) => team.id === teamId)
+          if (team) {
+            team.score += points
+          }
+        }),
+      ),
+
+    setGameStatus: (gameStatus) => set({ gameStatus }),
+
+    nextRound: () =>
+      set(
+        produce((state: GameState) => {
+          state.currentRound = Math.min(
+            state.currentRound + 1,
+            state.totalRounds,
+          )
+        }),
+      ),
+
+    resetGame: () =>
+      set({
+        teams: [],
+        gameStatus: "setup",
+        currentRound: 1,
+        settings: {},
+      }),
+
+    updateSettings: (newSettings) =>
+      set(
+        produce((state: GameState) => {
+          Object.assign(state.settings, newSettings)
+        }),
+      ),
+  }))
+
+export type GameStoreApi = ReturnType<typeof createGameStore>
+
+export const GameStoreContext = createContext<GameStoreApi | undefined>(
+  undefined,
+)
+
+export interface GameStoreProviderProps {
+  children: ReactNode
+  initialGameDetail?: GameDetailData
+}
+
+export const GameStoreProvider = ({
+  children,
+  initialGameDetail,
+}: GameStoreProviderProps) => {
+  const storeRef = useRef<GameStoreApi | null>(null)
+  if (storeRef.current === null) {
+    storeRef.current = createGameStore(initialGameDetail)
+  }
+
+  return (
+    <GameStoreContext.Provider value={storeRef.current}>
+      {children}
+    </GameStoreContext.Provider>
+  )
+}
+
+export const useGameStore = <T,>(
+  selector: (store: GameState & GameActions) => T,
+): T => {
+  const gameStoreContext = useContext(GameStoreContext)
+
+  if (!gameStoreContext) {
+    throw new Error(`useGameStore must be used within GameStoreProvider`)
+  }
+
+  return useStore(gameStoreContext, selector)
+}

--- a/service/app/src/mocks/utils/mockGenerators.ts
+++ b/service/app/src/mocks/utils/mockGenerators.ts
@@ -39,7 +39,8 @@ export const generateRandomDate = (daysAgo: number = 0): string => {
 export const generateMockGameList = (count: number): GameListItem[] => {
   const result: GameListItem[] = []
   for (let i = 0; i < count; i++) {
-    const id = generateFakeUUID()
+    // const id = generateFakeUUID()
+    const id = `${i}`
     const title = `게임${i + 1}`
     const questionCount = getRandomNumber(5, 20)
     const playCount = getRandomNumber(0, 200)

--- a/shared/design/src/components/input/index.tsx
+++ b/shared/design/src/components/input/index.tsx
@@ -133,8 +133,9 @@ export const Control = forwardRef<
     value?: string
     onChange?: (value: string) => void
     defaultValue?: string
+    onReset?: () => void
   }
->(({ children, value, onChange, defaultValue, ...props }, ref) => {
+>(({ children, value, onChange, defaultValue, onReset, ...props }, ref) => {
   const { type, state } = useInputContext("textField")
 
   const [controlledValue, setValue] = useControllableState({
@@ -155,7 +156,14 @@ export const Control = forwardRef<
         />
       </Form.Control>
       {type === "reset" && (
-        <DestructiveSolidIconButton type="button" onClick={() => setValue("")}>
+        <DestructiveSolidIconButton
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            setValue("")
+            onReset?.()
+          }}
+        >
           <Trash className={iconVariants({ type })} />
         </DestructiveSolidIconButton>
       )}

--- a/shared/design/src/components/playerStatus/index.tsx
+++ b/shared/design/src/components/playerStatus/index.tsx
@@ -1,4 +1,5 @@
 import { Add, Minus } from "../../icons"
+import { cn } from "../../utils/cn"
 import { SecondaryPlainIconButton } from "../button"
 
 interface PlayerStatusProps {
@@ -7,6 +8,7 @@ interface PlayerStatusProps {
   scoreView?: boolean
   onScoreIncrease?: () => void
   onScoreDecrease?: () => void
+  className?: string
 }
 
 export const PlayerStatus = ({
@@ -15,9 +17,15 @@ export const PlayerStatus = ({
   scoreView = true,
   onScoreIncrease,
   onScoreDecrease,
+  className,
 }: PlayerStatusProps) => {
   return (
-    <div className="max-h-[118px] w-[350px] rounded-[10px] bg-background-primary p-[20px_39px]">
+    <div
+      className={cn(
+        "max-h-[118px] w-[350px] rounded-[10px] bg-background-primary p-[20px_39px]",
+        className,
+      )}
+    >
       <div className="flex h-10 min-h-10 items-center gap-5">
         <h3 className="typography-heading-xl-medium flex h-10 min-w-0 flex-1 items-center">
           <span className="block w-full truncate">{name}</span>


### PR DESCRIPTION
## 📝 설명
500,501 참가사 설정 페이지 기능 개발
## 🛠️ 주요 변경 사항
- 게임 진행 관련한 url 이동을 setup/play/result로 정의 230d8b40dec7eafa6ed9a59c794c15325f30c117
- PlayerStatus 컴포넌트에 className override 추가 f0ce6d6afa944ae4ad460c52a4e36060fead3be0
- game mockData의 id속성을 기존 uuid생성에서 index를 통한 string으로 변경 5b30d5cdfaee84b3d3f3984b4818e35412761729

## 리뷰 시 고려해야 할 사항

- mockData에서 id를 uuid로 생성하면, 현재 테스트하는 입장에서 어떤값을 입력해도 성공 케이스를 재현할수없어서 이를 index를 기반으로한 단순 string으로 변경했는데, 이슈가 있을까요?

- 컴포넌트 분리 및 효율적인 로직보다는, 빠르게 기능 및 레이아웃을 개발하는데에 초점을 맞췄습니다. 
게임 진행페이지까지 개발된 이후에, 종합해서 리팩토링을 진행할 예정입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 게임 참가 팀 관리, 팀 이름 편집, 팀 추가/삭제, 유효성 검사 등이 포함된 게임 설정 페이지가 추가되었습니다.
  * 게임 상세 정보를 불러와 하위 컴포넌트에 전달하는 레이아웃이 도입되었습니다.
  * 게임 플레이, 결과, 설정 등 각 게임 라우트에 대응하는 신규 페이지가 추가되었습니다.
  * 게임 상태와 팀 관리, 점수 조정 등을 위한 전역 상태 관리 기능이 추가되었습니다.
  * 입력 컴포넌트(Control)에 onReset 콜백이 추가되었습니다.
  * PlayerStatus 컴포넌트에 className prop이 추가되어 스타일 확장이 가능해졌습니다.

* **문서**
  * Figma XML 디자인 파일을 Next.js + TypeScript + Tailwind CSS 코드로 변환하는 규칙 및 체크리스트 가이드 문서가 추가되었습니다.

* **스타일**
  * 여러 컴포넌트 및 파일에서 코드 포맷팅 및 불필요한 공백이 정리되었습니다.

* **테스트/목업**
  * 목업 게임 리스트 생성 시 id 생성 방식이 단순 문자열로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->