### PR TITLE
게임 카드에 공유 상태 추가

### DIFF
--- a/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
+++ b/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
@@ -61,6 +61,7 @@ export const GameLibraryGrid = ({
                   title={game.gameTitle}
                   questionCount={game.questionCount}
                   imageUrl={game.gameThumbnailUrl}
+                  shared={game.isShared}
                 />
               </div>
             ))}

--- a/service/app/src/widgets/GameSection.tsx
+++ b/service/app/src/widgets/GameSection.tsx
@@ -142,6 +142,7 @@ export const GameSection = ({ className = "" }: GameSectionProps) => {
                   title={game.gameTitle}
                   questionCount={game.questionCount}
                   imageUrl={game.gameThumbnailUrl}
+                  shared={game.isShared}
                 />
               </div>
             ))}

--- a/shared/design/src/components/gameCard/index.tsx
+++ b/shared/design/src/components/gameCard/index.tsx
@@ -74,6 +74,23 @@ const badgeVariants = cva(
   },
 )
 
+const sharedBadgeVariants = cva(
+  "absolute bottom-2 left-2 inline-flex items-center justify-center gap-[10px] rounded-[2px] bg-background-badge-secondary px-[5px] py-[2px]",
+  {
+    variants: {
+      type: {
+        libraryGame: "block",
+        myGame: "block",
+        gamePreview: "hidden",
+        onlyTitleGamePreview: "hidden",
+      },
+    },
+    defaultVariants: {
+      type: "libraryGame",
+    },
+  },
+)
+
 const titleVariants = cva(
   "overflow-hidden text-ellipsis text-[19px] font-bold leading-[120%] text-text-primary",
   {
@@ -117,6 +134,7 @@ type BaseGameCardProps = {
   questionCount: number
   imageUrl?: string
   className?: string
+  shared?: boolean
 }
 
 type LibraryGameCardProps = BaseGameCardProps & {
@@ -151,7 +169,7 @@ type GameCardProps =
 
 export const GameCard = forwardRef<HTMLDivElement, GameCardProps>(
   (props, ref) => {
-    const { type, title, questionCount, imageUrl, className } = props
+    const { type, title, questionCount, imageUrl, className, shared } = props
 
     const renderThumbnail = () => (
       <div className={cn(thumbnailVariants({ type }), className)}>
@@ -164,6 +182,13 @@ export const GameCard = forwardRef<HTMLDivElement, GameCardProps>(
             {questionCount}문제
           </span>
         </div>
+        {shared && (
+          <div className={cn(sharedBadgeVariants({ type }))}>
+            <span className="text-[13px] font-normal leading-[120%] text-text-inverse">
+              공유
+            </span>
+          </div>
+        )}
       </div>
     )
 

--- a/shared/design/src/stories/gameCard.stories.tsx
+++ b/shared/design/src/stories/gameCard.stories.tsx
@@ -8,6 +8,7 @@ type StorybookGameCardProps = {
   questionCount: number
   imageUrl?: string
   optionView?: boolean
+  shared?: boolean
   onEdit?: () => void
   onShare?: () => void
   onDelete?: () => void
@@ -198,6 +199,9 @@ CVA(Class Variance Authority)를 사용한 일관된 스타일링으로 디자�
       control: { type: "boolean" },
       if: { arg: 'type', eq: 'myGame' },
     },
+    shared: {
+      control: { type: "boolean" },
+    },
   },
 }
 
@@ -254,5 +258,26 @@ export const NoImage: Story = {
     type: "libraryGame",
     title: "이미지 없는 게임",
     questionCount: 12,
+  },
+}
+
+export const SharedGame: Story = {
+  args: {
+    type: "libraryGame",
+    title: "공유된 게임",
+    questionCount: 10,
+    imageUrl: "https://picsum.photos/id/237/536/354",
+    shared: true,
+  },
+}
+
+export const SharedMyGame: Story = {
+  args: {
+    type: "myGame",
+    title: "내가 만든 공유 게임",
+    questionCount: 15,
+    imageUrl: "https://picsum.photos/id/237/536/354",
+    shared: true,
+    optionView: false,
   },
 }


### PR DESCRIPTION
## 📝 설명

gameCard 컴포넌트에 '공유' 뱃지를 추가했습니다.

## 🛠️ 주요 변경 사항

- gameCard 썸네일 좌측 하단에 '공유' 뱃지 추가 14514f7d2c2c3b81582e20e150a6dac3f3b0fd15

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공유된 게임일 경우 카드 썸네일 좌측 하단에 “공유” 배지를 조건부로 표시합니다. 기존 배지와 함께 노출되며 카드 유형별 가시성 규칙을 따릅니다.
  * 게임 라이브러리 및 게임 섹션 목록에서 공유 상태가 카드에 반영됩니다.
* 문서
  * 스토리북에 공유 상태를 제어하는 옵션을 추가하고, 공유 상태 예제를 보여주는 스토리(SharedGame, SharedMyGame)를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->