### PR TITLE
대시보드 페이지 라우트 및 페이지 생성

### DIFF
--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -21,11 +21,7 @@ import { GamePreview } from "@/entities/game/ui/components/gamePreview"
 export default function DashboardPage() {
   const router = useRouter()
   const [_searchQuery, _setSearchQuery] = useState("")
-  const {
-    user,
-    isLoading: _authLoading,
-    isAuthenticated,
-  } = useAuth()
+  const { user, isLoading: _authLoading, isAuthenticated } = useAuth()
 
   const { games, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useInfiniteGameList({
@@ -124,11 +120,7 @@ export default function DashboardPage() {
 
   const rightContent = (
     <>
-      <PrimaryBoxButton
-        size="sm"
-        _style="solid"
-        onClick={handleCreateGame}
-      >
+      <PrimaryBoxButton size="sm" _style="solid" onClick={handleCreateGame}>
         <Add />
         게임 만들기
       </PrimaryBoxButton>

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import {
+  PrimaryBoxButton,
+  SecondaryGhostIconButton,
+} from "@shared/design/src/components/button"
+import { Navigation } from "@shared/design/src/components/navigation"
+import { Add, Sun } from "@shared/design/src/icons"
+import Image from "next/image"
+import { useRouter } from "next/navigation"
+import { overlay } from "overlay-kit"
+import { useState } from "react"
+
+import { useAuth } from "@/entities/auth"
+import { GameListItem } from "@/entities/game"
+import { getGameDetail } from "@/entities/game/api/getGameDetail"
+import { useInfiniteGameList } from "@/entities/game/model/useInfiniteGameList"
+import { GameLibraryGrid } from "@/entities/game/ui/components"
+import { GamePreview } from "@/entities/game/ui/components/gamePreview"
+
+export default function DashboardPage() {
+  const router = useRouter()
+  const [_searchQuery, _setSearchQuery] = useState("")
+  const {
+    user,
+    isLoading: _authLoading,
+    isAuthenticated,
+  } = useAuth()
+
+  const { games, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useInfiniteGameList({
+      limit: 19,
+    })
+
+  const handleCreateGame = () => {
+    router.push("/create")
+  }
+
+  const handleGameClick = async (game: GameListItem) => {
+    try {
+      const gameDetailRes = await getGameDetail(game.gameId)
+
+      if (gameDetailRes.result === "SUCCESS" && gameDetailRes.data) {
+        const gameDetail = gameDetailRes.data
+
+        overlay.open(({ close, isOpen }) => {
+          const handleStartGame = () => {
+            close()
+            router.push(`/game/${game.gameId}`)
+          }
+
+          return (
+            <GamePreview
+              gameTitle={gameDetail.gameTitle}
+              creatorName={gameDetail.nickname}
+              questionCount={gameDetail.questionCount}
+              questions={gameDetail.questions.map((question) => ({
+                id: question.questionId.toString(),
+                title: question.questionText,
+                imageUrl: question.imageUrl,
+              }))}
+              onClose={close}
+              onStartGame={handleStartGame}
+              isOpen={isOpen}
+            />
+          )
+        })
+      } else {
+        console.error("Failed to fetch game detail")
+      }
+    } catch (error) {
+      console.error("Error fetching game detail:", error)
+    }
+  }
+
+  const handleLoadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }
+
+  const handleEditGame = (game: GameListItem) => {
+    console.log("Edit game:", game.gameId)
+    // TODO: 게임 수정 페이지로 이동
+    router.push(`/create?gameId=${game.gameId}`)
+  }
+
+  const handleShareGame = (game: GameListItem) => {
+    console.log("Share game:", game.gameId)
+    // TODO: 게임 공유 기능 구현
+  }
+
+  const handleDeleteGame = (game: GameListItem) => {
+    console.log("Delete game:", game.gameId)
+    // TODO: 게임 삭제 확인 다이얼로그 표시
+  }
+
+  const handleThemeToggle = () => {}
+
+  const handleLogoClick = () => {
+    router.push("/")
+  }
+
+  const leftContent = (
+    <div
+      className="flex h-[60px] w-[268px] cursor-pointer items-center justify-center p-3.5"
+      onClick={handleLogoClick}
+    >
+      <Image
+        src="/logo.svg"
+        alt="홈 로고"
+        className="size-full"
+        width={268}
+        height={60}
+      />
+    </div>
+  )
+
+  const centerContent = (
+    <h1 className="typography-heading-xl-semibold text-text-primary">
+      내 게임
+    </h1>
+  )
+
+  const rightContent = (
+    <>
+      <PrimaryBoxButton
+        size="sm"
+        _style="solid"
+        onClick={handleCreateGame}
+      >
+        <Add />
+        게임 만들기
+      </PrimaryBoxButton>
+
+      {isAuthenticated ? (
+        <div className="flex size-[42px] items-center justify-center rounded-full bg-gray-300">
+          <Image
+            src={user?.profileImageUrl || "/avatar.svg"}
+            alt="사용자 아바타"
+            className="size-full rounded-full"
+            width={42}
+            height={42}
+          />
+        </div>
+      ) : (
+        <div className="flex size-[42px] items-center justify-center rounded-full bg-gray-300">
+          <Image
+            src="/avatar.svg"
+            alt="기본 아바타"
+            className="size-full rounded-full"
+            width={42}
+            height={42}
+          />
+        </div>
+      )}
+
+      <SecondaryGhostIconButton onClick={handleThemeToggle}>
+        <Sun />
+      </SecondaryGhostIconButton>
+    </>
+  )
+
+  return (
+    <main className="min-h-screen bg-background-primary">
+      <Navigation
+        type="title"
+        playGame={false}
+        leftContent={leftContent}
+        centerContent={centerContent}
+        rightContent={rightContent}
+      />
+      <div className="flex w-full flex-col items-center gap-[45px] pt-[40px]">
+        <GameLibraryGrid
+          games={games}
+          isLoading={isLoading}
+          isFetchingNextPage={isFetchingNextPage}
+          hasNextPage={hasNextPage}
+          onCreateGame={handleCreateGame}
+          onGameClick={handleGameClick}
+          onLoadMore={handleLoadMore}
+          isDashboard={true}
+          onEditGame={handleEditGame}
+          onShareGame={handleShareGame}
+          onDeleteGame={handleDeleteGame}
+        />
+      </div>
+    </main>
+  )
+}

--- a/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
+++ b/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
@@ -72,7 +72,9 @@ export const GameLibraryGrid = ({
                   shared={game.isShared}
                   onEdit={isDashboard ? () => onEditGame?.(game) : undefined}
                   onShare={isDashboard ? () => onShareGame?.(game) : undefined}
-                  onDelete={isDashboard ? () => onDeleteGame?.(game) : undefined}
+                  onDelete={
+                    isDashboard ? () => onDeleteGame?.(game) : undefined
+                  }
                 />
               </div>
             ))}

--- a/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
+++ b/service/app/src/entities/game/ui/components/gameLibraryGrid.tsx
@@ -15,6 +15,10 @@ interface GameLibraryGridProps {
   onCreateGame?: () => void
   onGameClick?: (game: GameListItem) => void
   onLoadMore?: () => void
+  isDashboard?: boolean
+  onEditGame?: (game: GameListItem) => void
+  onShareGame?: (game: GameListItem) => void
+  onDeleteGame?: (game: GameListItem) => void
 }
 
 export const GameLibraryGrid = ({
@@ -26,6 +30,10 @@ export const GameLibraryGrid = ({
   onCreateGame,
   onGameClick,
   onLoadMore,
+  isDashboard = false,
+  onEditGame,
+  onShareGame,
+  onDeleteGame,
 }: GameLibraryGridProps) => {
   const setObserverRef = useIntersectionObserver(() => {
     if (hasNextPage && !isFetchingNextPage && onLoadMore) {
@@ -57,11 +65,14 @@ export const GameLibraryGrid = ({
                 className="cursor-pointer"
               >
                 <GameCard
-                  type="libraryGame"
+                  type={isDashboard ? "myGame" : "libraryGame"}
                   title={game.gameTitle}
                   questionCount={game.questionCount}
                   imageUrl={game.gameThumbnailUrl}
                   shared={game.isShared}
+                  onEdit={isDashboard ? () => onEditGame?.(game) : undefined}
+                  onShare={isDashboard ? () => onShareGame?.(game) : undefined}
+                  onDelete={isDashboard ? () => onDeleteGame?.(game) : undefined}
                 />
               </div>
             ))}


### PR DESCRIPTION
## 📝 설명

<!--
    작업한 내용을 요약해서 작성
 -->

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

나중에 dev로 base branch 바꾸겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - “내 게임” 대시보드 페이지 추가: 홈 이동, 중앙 제목, 게임 만들기 버튼, 사용자 아바타, 테마 전환 제공.
  - 내 게임 목록 무한 스크롤/더보기 지원, 카드 클릭 시 미리보기 모달에서 게임 정보 확인 및 바로 시작/이동 가능.
- 개선
  - 게임 라이브러리 그리드에 대시보드 모드 추가: 카드 타입 전환 및 편집/공유/삭제 액션 핸들러 연동으로 관리 기능 확장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->