### PR TITLE
로그아웃 연동

### DIFF
--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import {
   PrimaryBoxButton,
   SecondaryGhostIconButton,
+  SecondaryOutlineBoxButton,
 } from "@shared/design/src/components/button"
 import { Navigation } from "@shared/design/src/components/navigation"
 import { Add, Sun } from "@shared/design/src/icons"
@@ -29,7 +30,8 @@ export default function DashboardPage() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [_searchQuery, _setSearchQuery] = useState("")
-  const { user, isLoading: _authLoading, isAuthenticated } = useAuth()
+  const { user, isLoading: _authLoading, isAuthenticated, logout } = useAuth()
+  const [listButton, setListButton] = useState(false)
 
   const {
     games,
@@ -155,6 +157,16 @@ export default function DashboardPage() {
     router.push("/")
   }
 
+  const handleAvatarClick = () => {
+    setListButton(!listButton)
+  }
+
+  const handleLogoutClick = () => {
+    logout()
+    setListButton(false)
+    router.push("/")
+  }
+
   const leftContent = (
     <div
       className="flex h-[60px] w-[268px] cursor-pointer items-center justify-center p-3.5"
@@ -184,14 +196,30 @@ export default function DashboardPage() {
       </PrimaryBoxButton>
 
       {isAuthenticated ? (
-        <div className="flex size-[42px] items-center justify-center rounded-full bg-gray-300">
-          <Image
-            src={user?.profileImageUrl || "/avatar.svg"}
-            alt="사용자 아바타"
-            className="size-full rounded-full"
-            width={42}
-            height={42}
-          />
+        <div className="relative">
+          <div
+            className="flex size-[42px] cursor-pointer items-center justify-center rounded-full bg-gray-300"
+            onClick={handleAvatarClick}
+          >
+            <Image
+              src={user?.profileImageUrl || "/avatar.svg"}
+              alt="사용자 아바타"
+              className="size-full rounded-full"
+              width={42}
+              height={42}
+            />
+          </div>
+          {listButton && (
+            <div className="absolute right-0 top-full z-10 mt-2">
+              <SecondaryOutlineBoxButton 
+                size="md" 
+                onClick={handleLogoutClick}
+                className="whitespace-nowrap"
+              >
+                로그아웃
+              </SecondaryOutlineBoxButton>
+            </div>
+          )}
         </div>
       ) : (
         <div className="flex size-[42px] items-center justify-center rounded-full bg-gray-300">

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -211,8 +211,8 @@ export default function DashboardPage() {
           </div>
           {listButton && (
             <div className="absolute right-0 top-full z-10 mt-2">
-              <SecondaryOutlineBoxButton 
-                size="md" 
+              <SecondaryOutlineBoxButton
+                size="md"
                 onClick={handleLogoutClick}
                 className="whitespace-nowrap"
               >

--- a/service/app/src/app/page.tsx
+++ b/service/app/src/app/page.tsx
@@ -1,13 +1,17 @@
+"use client"
+
+import { useAuth } from "@/entities/auth"
+
 import { GameSection } from "../widgets/GameSection"
 import { HeroSection } from "../widgets/HeroSection"
 import { HomeNavigation } from "../widgets/HomeNavigation"
 
 export default function Home() {
-  const isLoggedIn = false
+  const { isAuthenticated } = useAuth()
 
   return (
     <main className="min-h-screen bg-background-primary">
-      <HomeNavigation isLoggedIn={isLoggedIn} />
+      <HomeNavigation isLoggedIn={isAuthenticated} />
       <div className="h-[157px]" />
       <HeroSection />
       <div className="h-[70px]" />

--- a/service/app/src/widgets/HomeNavigation.tsx
+++ b/service/app/src/widgets/HomeNavigation.tsx
@@ -104,8 +104,8 @@ export const HomeNavigation = ({
                 </div>
                 {listButton && (
                   <div className="absolute right-0 top-full z-10 mt-2">
-                    <SecondaryOutlineBoxButton 
-                      size="md" 
+                    <SecondaryOutlineBoxButton
+                      size="md"
                       onClick={handleLogoutClick}
                       className="whitespace-nowrap"
                     >
@@ -117,8 +117,8 @@ export const HomeNavigation = ({
             </>
           ) : (
             <>
-              <SecondaryOutlineBoxButton 
-                size="md" 
+              <SecondaryOutlineBoxButton
+                size="md"
                 onClick={handleLoginClick}
                 disabled={authLoading}
               >

--- a/service/app/src/widgets/HomeNavigation.tsx
+++ b/service/app/src/widgets/HomeNavigation.tsx
@@ -8,6 +8,9 @@ import {
 import { Add, Sun } from "@shared/design/src/icons"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+import { useAuth } from "@/entities/auth"
 
 interface HomeNavigationProps {
   isLoggedIn?: boolean
@@ -19,8 +22,12 @@ export const HomeNavigation = ({
   className = "",
 }: HomeNavigationProps) => {
   const router = useRouter()
+  const { user, isLoading: authLoading, login, logout } = useAuth()
+  const [listButton, setListButton] = useState(false)
 
-  const handleMyGamesClick = () => {}
+  const handleMyGamesClick = () => {
+    router.push("/dashboard")
+  }
 
   const handleCreateGameClick = () => {
     router.push("/create")
@@ -28,9 +35,22 @@ export const HomeNavigation = ({
 
   const handleThemeToggle = () => {}
 
-  const handleAvatarClick = () => {}
+  const handleAvatarClick = () => {
+    setListButton(!listButton)
+  }
 
-  const handleLoginClick = () => {}
+  const handleLoginClick = async () => {
+    try {
+      await login()
+    } catch (error) {
+      console.error("Login failed:", error)
+    }
+  }
+
+  const handleLogoutClick = () => {
+    logout()
+    setListButton(false)
+  }
 
   return (
     <nav
@@ -69,22 +89,39 @@ export const HomeNavigation = ({
                 게임 만들기
               </PrimaryBoxButton>
 
-              <div
-                className="flex size-[42px] cursor-pointer items-center justify-center rounded-full bg-gray-300"
-                onClick={handleAvatarClick}
-              >
-                <Image
-                  src="/avatar.svg"
-                  alt="사용자 아바타"
-                  className="size-full rounded-full"
-                  width={42}
-                  height={42}
-                />
+              <div className="relative">
+                <div
+                  className="flex size-[42px] cursor-pointer items-center justify-center rounded-full bg-gray-300"
+                  onClick={handleAvatarClick}
+                >
+                  <Image
+                    src={user?.profileImageUrl || "/avatar.svg"}
+                    alt="사용자 아바타"
+                    className="size-full rounded-full"
+                    width={42}
+                    height={42}
+                  />
+                </div>
+                {listButton && (
+                  <div className="absolute right-0 top-full z-10 mt-2">
+                    <SecondaryOutlineBoxButton 
+                      size="md" 
+                      onClick={handleLogoutClick}
+                      className="whitespace-nowrap"
+                    >
+                      로그아웃
+                    </SecondaryOutlineBoxButton>
+                  </div>
+                )}
               </div>
             </>
           ) : (
             <>
-              <SecondaryOutlineBoxButton size="md" onClick={handleLoginClick}>
+              <SecondaryOutlineBoxButton 
+                size="md" 
+                onClick={handleLoginClick}
+                disabled={authLoading}
+              >
                 <Image
                   src="/kakao-logo.png"
                   alt="카카오 로고"


### PR DESCRIPTION
## 📝 설명

- 아바타 버튼 아래에 드롭다운 버튼 추가 (로그아웃)
- 홈 화면 네비게이션 로그인 기능 연동

## 🛠️ 주요 변경 사항

- 홈 네비게이션 로그인 연동 2f459e68c10b6f15f3dfd48ee98973a8ae90b7e1
- 아바타 버튼 아래에 로그아웃 드롭다운 추가 491cd20d2cef479efd7adc5b405fd709f49cbeea

## 리뷰 시 고려해야 할 사항

figma랑 구현을 다르게 가고 있는 중 + 급하게 구현 중이라 현재 ui에 중복이 있습니다. 이번 주 중으로 리팩토링 하겠습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 아바타 클릭 시 드롭다운에 로그아웃 옵션 추가(“로그아웃” 버튼).
  - 로그인/로그아웃 흐름 연동: 카카오 로그인 버튼 로딩 중 비활성화, 오류 처리 개선.
  - 인증 상태에 따라 내비게이션이 동적으로 표시(프로필 이미지 표시, 미로그인 시 기존 표시 유지).
  - “내 게임” 메뉴가 대시보드로 이동하도록 동작 개선.
  - 홈 화면이 인증 상태를 반영해 로그인 여부 기반으로 탐색 구성요소를 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->