### PR TITLE
게임 수정 기능 구현

### DIFF
--- a/service/app/src/app/create/page.tsx
+++ b/service/app/src/app/create/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useSearchParams } from "next/navigation"
+
 import { GameCreationProvider } from "../../entities/game/model/state/create/gameCreationContext"
 import { CreateGameNavigation } from "../../entities/game/ui/components/createGameNavigation"
 import { FileUploadArea } from "../../entities/game/ui/components/fileUploadArea"
@@ -7,6 +9,7 @@ import { QuestionInputForm } from "../../entities/game/ui/components/questionInp
 import { QuestionList } from "../../entities/game/ui/components/questionList"
 
 function CreateGameContent() {
+
   return (
     <main className="min-h-screen bg-neutral-white">
       <CreateGameNavigation />
@@ -26,8 +29,11 @@ function CreateGameContent() {
 }
 
 export default function CreateGamePage() {
+  const searchParams = useSearchParams()
+  const gameId = searchParams.get("gameId")
+
   return (
-    <GameCreationProvider>
+    <GameCreationProvider gameId={gameId}>
       <CreateGameContent />
     </GameCreationProvider>
   )

--- a/service/app/src/entities/game/api/updateGame.ts
+++ b/service/app/src/entities/game/api/updateGame.ts
@@ -69,3 +69,20 @@ export const updateGame = async (
 
   return response.json()
 }
+
+// 게임 수정용 함수 (기존 이미지 유지)
+export const updateGameWithoutNewImages = async (
+  gameData: GameUpdateRequest,
+  gameId: UUID,
+): Promise<ApiResponse<null>> => {
+  const response = await fetchClient.fetch(`/games/${gameId}`, {
+    method: "PUT",
+    body: JSON.stringify(gameData),
+  })
+
+  if (!response.ok) {
+    return mapStatusToErrorResponse(response.status)
+  }
+
+  return response.json()
+}

--- a/service/app/src/entities/game/model/gameRequest.ts
+++ b/service/app/src/entities/game/model/gameRequest.ts
@@ -30,20 +30,17 @@ export interface GameUpdateQuestion {
   imageUrl: string | null
   questionText: string
   questionAnswer: string
-  version: number | null
 }
 
 export interface GameCreateRequest {
   gameId: UUID
   gameTitle: string
-  gameCreatorEmail: string
   gameThumbnailUrl: string | null
   questions: GameCreateQuestion[]
 }
 
 export interface GameUpdateRequest {
   gameTitle: string
-  gameCreatorEmail: string
   gameThumbnailUrl: string | null
   questions: GameUpdateQuestion[]
   version: number

--- a/service/app/src/entities/game/model/state/create/actions.ts
+++ b/service/app/src/entities/game/model/state/create/actions.ts
@@ -21,6 +21,20 @@ export type GameCreationAction =
   | { type: "SAVE_GAME_START" }
   | { type: "SAVE_GAME_SUCCESS" }
   | { type: "SAVE_GAME_ERROR"; payload: string }
+  | {
+      type: "INITIALIZE_FROM_GAME_DETAIL"
+      payload: {
+        gameTitle: string
+        questions: Array<{
+          questionId: string
+          questionText: string
+          answer: string
+          imageUrl: string | null
+        }>
+        version: number
+      }
+    }
+  | { type: "SET_GAME_VERSION"; payload: number }
 
 interface PopupState {
   showExitConfirmation: boolean
@@ -81,14 +95,14 @@ export const gameCreationActions = {
     payload: { questionId, file, previewUrl },
   }),
 
-  showPopup: (popupType: keyof PopupState): GameCreationAction => ({
+  showPopup: (popup: keyof PopupState): GameCreationAction => ({
     type: "SHOW_POPUP",
-    payload: popupType,
+    payload: popup,
   }),
 
-  hidePopup: (popupType: keyof PopupState): GameCreationAction => ({
+  hidePopup: (popup: keyof PopupState): GameCreationAction => ({
     type: "HIDE_POPUP",
-    payload: popupType,
+    payload: popup,
   }),
 
   saveGameStart: (): GameCreationAction => ({
@@ -102,5 +116,24 @@ export const gameCreationActions = {
   saveGameError: (error: string): GameCreationAction => ({
     type: "SAVE_GAME_ERROR",
     payload: error,
+  }),
+
+  initializeFromGameDetail: (
+    gameTitle: string,
+    questions: Array<{
+      questionId: string
+      questionText: string
+      answer: string
+      imageUrl: string | null
+    }>,
+    version: number,
+  ): GameCreationAction => ({
+    type: "INITIALIZE_FROM_GAME_DETAIL",
+    payload: { gameTitle, questions, version },
+  }),
+
+  setGameVersion: (version: number): GameCreationAction => ({
+    type: "SET_GAME_VERSION",
+    payload: version,
   }),
 }

--- a/service/app/src/entities/game/model/state/create/gameCreationContext.tsx
+++ b/service/app/src/entities/game/model/state/create/gameCreationContext.tsx
@@ -1,6 +1,15 @@
 "use client"
 
-import { createContext, ReactNode, useContext } from "react"
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+import { getGameDetail } from "@/entities/game/api/getGameDetail"
 
 import { useGameCreation } from "./useGameCreation"
 
@@ -8,8 +17,55 @@ type GameCreationContextType = ReturnType<typeof useGameCreation>
 
 const GameCreationContext = createContext<GameCreationContextType | null>(null)
 
-export function GameCreationProvider({ children }: { children: ReactNode }) {
+interface GameCreationProviderProps {
+  children: ReactNode
+  gameId?: string | null
+}
+
+export function GameCreationProvider({
+  children,
+  gameId,
+}: GameCreationProviderProps) {
   const gameCreation = useGameCreation()
+  const [isLoading, setIsLoading] = useState(false)
+  const hasLoaded = useRef(false)
+
+  useEffect(() => {
+    if (gameId && !hasLoaded.current) {
+      hasLoaded.current = true
+      setIsLoading(true)
+      
+      const loadGameData = async () => {
+        try {
+          const response = await getGameDetail(gameId)
+          if (response.result === "SUCCESS" && response.data) {
+            const gameDetail = response.data
+
+            gameCreation.actions.initializeFromGameDetail(
+              gameDetail.gameTitle,
+              gameDetail.questions.map((question) => ({
+                questionId: question.questionId.toString(),
+                questionText: question.questionText,
+                answer: question.questionAnswer,
+                imageUrl: question.imageUrl,
+              })),
+              gameDetail.version,
+            )
+          }
+        } catch (error) {
+          console.error("Failed to load game data:", error)
+        } finally {
+          setIsLoading(false)
+        }
+      }
+
+      loadGameData()
+    }
+  }, [gameId, gameCreation.actions])
+
+  if (isLoading) {
+    return <div>게임 데이터를 불러오는 중...</div>
+  }
 
   return (
     <GameCreationContext.Provider value={gameCreation}>

--- a/service/app/src/entities/game/model/state/create/reducer.ts
+++ b/service/app/src/entities/game/model/state/create/reducer.ts
@@ -95,17 +95,19 @@ export const gameCreationReducer = (
 
     case "UPLOAD_IMAGE_START": {
       const { questionId, file, previewUrl } = action.payload
+      const updatedQuestions = state.questions.map((question) =>
+        question.id === questionId
+          ? {
+              ...question,
+              imageFile: file,
+              previewImageUrl: previewUrl,
+            }
+          : question,
+      )
 
       return {
         ...state,
-        loading: {
-          ...state.loading,
-          isUploading: true,
-        },
-        questions: updateQuestion(state.questions, questionId, {
-          imageFile: file,
-          previewImageUrl: previewUrl,
-        }),
+        questions: updatedQuestions,
       }
     }
 
@@ -156,6 +158,35 @@ export const gameCreationReducer = (
           ...state.loading,
           isSaving: false,
         },
+      }
+
+    case "INITIALIZE_FROM_GAME_DETAIL": {
+      const { gameTitle, questions, version } = action.payload
+
+      // 기존 질문들을 새로운 데이터로 교체
+      const newQuestions = questions.map((question, index) => ({
+        id: question.questionId,
+        text: question.questionText,
+        answer: question.answer,
+        imageFile: null,
+        imageUrl: question.imageUrl,
+        previewImageUrl: null,
+        order: index,
+      }))
+
+      return {
+        ...state,
+        gameName: gameTitle,
+        questions: newQuestions,
+        selectedQuestionId: newQuestions.length > 0 ? newQuestions[0].id : null,
+        gameVersion: version,
+      }
+    }
+
+    case "SET_GAME_VERSION":
+      return {
+        ...state,
+        gameVersion: action.payload,
       }
 
     default:

--- a/service/app/src/entities/game/model/state/create/state.ts
+++ b/service/app/src/entities/game/model/state/create/state.ts
@@ -27,6 +27,7 @@ export interface GameCreationState {
   gameName: string
   questions: Question[]
   selectedQuestionId: string | null
+  gameVersion?: number
 
   popups: PopupState
   loading: LoadingState

--- a/service/app/src/entities/game/model/state/create/useGameCreation.ts
+++ b/service/app/src/entities/game/model/state/create/useGameCreation.ts
@@ -83,6 +83,32 @@ export const useGameCreation = () => {
     dispatch(gameCreationActions.saveGameError(error))
   }, [])
 
+  const initializeFromGameDetail = useCallback(
+    (
+      gameTitle: string,
+      questions: Array<{
+        questionId: string
+        questionText: string
+        answer: string
+        imageUrl: string | null
+      }>,
+      version: number,
+    ) => {
+      dispatch(
+        gameCreationActions.initializeFromGameDetail(
+          gameTitle,
+          questions,
+          version,
+        ),
+      )
+    },
+    [],
+  )
+
+  const setGameVersion = useCallback((version: number) => {
+    dispatch(gameCreationActions.setGameVersion(version))
+  }, [])
+
   const derivedState = {
     gameNameError: selectors.gameNameError(state),
 
@@ -123,6 +149,8 @@ export const useGameCreation = () => {
       saveGameStart,
       saveGameSuccess,
       saveGameError,
+      initializeFromGameDetail,
+      setGameVersion,
     },
 
     selectors: derivedState,

--- a/service/app/src/entities/game/ui/interactions/saveButton.tsx
+++ b/service/app/src/entities/game/ui/interactions/saveButton.tsx
@@ -1,12 +1,12 @@
 import { PrimaryBoxButton } from "@shared/design/src/components/button"
 import { useQueryClient } from "@tanstack/react-query"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 
 import { validateQuestion } from "../../model"
 import { useGameCreationContext } from "../../model/state/create/gameCreationContext"
 import { selectors } from "../../model/state/create/selectors"
 import { useGamePopupActions } from "../../model/useGamePopupActions"
-import { saveGame } from "../../utils/gameSave"
+import { saveGame, updateExistingGame } from "../../utils/gameSave"
 
 export function SaveButton() {
   const { state, actions } = useGameCreationContext()
@@ -14,6 +14,8 @@ export function SaveButton() {
     useGamePopupActions()
   const router = useRouter()
   const queryClient = useQueryClient()
+  const searchParams = useSearchParams()
+  const gameId = searchParams.get("gameId")
 
   const handleSave = () => {
     const gameNameError = selectors.gameNameError(state)
@@ -42,10 +44,24 @@ export function SaveButton() {
 
         const cleanedQuestions = selectors.cleanedQuestions(state)
 
-        const result = await saveGame({
-          ...state,
-          questions: cleanedQuestions,
-        })
+        let result
+        if (gameId) {
+          // 게임 수정 모드
+          result = await updateExistingGame(
+            {
+              ...state,
+              questions: cleanedQuestions,
+            },
+            gameId,
+            state.gameVersion || 1,
+          )
+        } else {
+          // 새 게임 생성 모드
+          result = await saveGame({
+            ...state,
+            questions: cleanedQuestions,
+          })
+        }
 
         if (result.success) {
           actions.saveGameSuccess()
@@ -69,7 +85,7 @@ export function SaveButton() {
       onClick={handleSave}
       disabled={!selectors.canSave(state)}
     >
-      게임 저장
+      {gameId ? "게임 수정" : "게임 저장"}
     </PrimaryBoxButton>
   )
 }

--- a/service/app/src/entities/game/utils/gameSave.ts
+++ b/service/app/src/entities/game/utils/gameSave.ts
@@ -1,7 +1,8 @@
 import { v4 as uuidv4 } from "uuid"
 
 import { createGame, getPresignedUrlsForNewGame } from "../api"
-import { GameCreateRequest } from "../model"
+import { updateGameWithoutNewImages } from "../api/updateGame"
+import { GameCreateRequest, GameUpdateRequest } from "../model"
 import { GameCreationState } from "../model/state/create/state"
 import { uploadMultipleFilesToS3 } from "./s3Upload"
 
@@ -25,9 +26,32 @@ export const prepareGameData = (
   return {
     gameId,
     gameTitle: state.gameName.trim() || "게임1",
-    gameCreatorEmail: "user@example.com",
     gameThumbnailUrl: thumbnailUrl,
     questions: state.questions.map((question, index) => ({
+      questionOrder: index,
+      imageUrl: question.imageUrl || "",
+      questionText: question.text.trim(),
+      questionAnswer: question.answer.trim(),
+    })),
+  }
+}
+
+export const prepareUpdateGameData = (
+  state: GameCreationState,
+  version: number,
+): GameUpdateRequest => {
+  const firstQuestionWithImage = state.questions.find(
+    (question) => question.imageUrl || question.imageFile,
+  )
+
+  const thumbnailUrl = firstQuestionWithImage?.imageUrl || null
+
+  return {
+    version,
+    gameTitle: state.gameName.trim() || "게임1",
+    gameThumbnailUrl: thumbnailUrl,
+    questions: state.questions.map((question, index) => ({
+      questionId: parseInt(question.id),
       questionOrder: index,
       imageUrl: question.imageUrl || "",
       questionText: question.text.trim(),
@@ -121,6 +145,105 @@ export const saveGame = async (
     return {
       success: true,
       gameId: gameData.gameId,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "알 수 없는 오류가 발생했습니다.",
+    }
+  }
+}
+
+export const updateExistingGame = async (
+  state: GameCreationState,
+  gameId: string,
+  version: number,
+): Promise<GameSaveResult> => {
+  try {
+    // 기본 검증
+    if (!state.gameName.trim()) {
+      return {
+        success: false,
+        error: "게임 이름을 입력해주세요.",
+      }
+    }
+
+    if (state.questions.length === 0) {
+      return {
+        success: false,
+        error: "최소 1개 이상의 질문이 필요합니다.",
+      }
+    }
+
+    const questionsWithImages = state.questions.filter((q) => q.imageFile)
+
+    let presignedResponse = null
+
+    if (questionsWithImages.length > 0) {
+      const presignedRequest = {
+        images: questionsWithImages.map((question) => ({
+          imageName: `${question.id}.${question.imageFile!.name.split(".").pop()}`,
+          questionOrder: question.order,
+        })),
+      }
+
+      presignedResponse = await getPresignedUrlsForNewGame(
+        presignedRequest.images,
+      )
+
+      if (presignedResponse.result !== "SUCCESS" || !presignedResponse.data) {
+        return {
+          success: false,
+          error: "Presigned URL 발급에 실패했습니다.",
+        }
+      }
+
+      const imageFiles = questionsWithImages.map((q) => q.imageFile!)
+      const uploadResult = await uploadMultipleFilesToS3(
+        imageFiles,
+        presignedResponse.data.presignedUrls,
+      )
+
+      if (!uploadResult.success) {
+        return {
+          success: false,
+          error: uploadResult.error || "이미지 업로드에 실패했습니다.",
+        }
+      }
+    }
+
+    const gameData = prepareUpdateGameData(state, version)
+
+    if (presignedResponse && presignedResponse.data) {
+      gameData.questions = gameData.questions.map((question, index) => {
+        const presignedUrl = presignedResponse.data!.presignedUrls[index]
+        return {
+          ...question,
+          imageUrl: presignedUrl ? presignedUrl.key : "",
+        }
+      })
+
+      const firstImageUrl = presignedResponse.data.presignedUrls[0]?.key
+      if (firstImageUrl) {
+        gameData.gameThumbnailUrl = firstImageUrl
+      }
+    }
+
+    const updateResponse = await updateGameWithoutNewImages(gameData, gameId)
+
+    if (updateResponse.result !== "SUCCESS") {
+      return {
+        success: false,
+        error: "게임 수정에 실패했습니다.",
+      }
+    }
+
+    return {
+      success: true,
+      gameId: gameId,
     }
   } catch (error) {
     return {

--- a/service/app/src/mocks/__tests__/gameHandlers.test.ts
+++ b/service/app/src/mocks/__tests__/gameHandlers.test.ts
@@ -135,7 +135,6 @@ describe("Game API Handlers", () => {
     const mockGameCreateRequest: GameCreateRequest = {
       gameId: "test-game-123",
       gameTitle: "테스트 게임",
-      gameCreatorEmail: "test@example.com",
       gameThumbnailUrl: "https://example.com/thumbnail.jpg",
       questions: [
         {
@@ -218,7 +217,6 @@ describe("Game API Handlers", () => {
   describe("PUT /games/:gameId", () => {
     const mockGameUpdateRequest: GameUpdateRequest = {
       gameTitle: "수정된 게임 제목",
-      gameCreatorEmail: "test@example.com",
       gameThumbnailUrl: "https://example.com/new-thumbnail.jpg",
       version: 1,
       questions: [
@@ -227,7 +225,6 @@ describe("Game API Handlers", () => {
           questionAnswer: "수정된 정답 1",
           questionOrder: 0,
           imageUrl: "https://example.com/image1.jpg",
-          version: 1,
         },
       ],
     }
@@ -236,7 +233,6 @@ describe("Game API Handlers", () => {
       const createRequest: GameCreateRequest = {
         gameId: "update-test-game",
         gameTitle: "원본 게임",
-        gameCreatorEmail: "test@example.com",
         gameThumbnailUrl: "https://example.com/thumbnail.jpg",
         questions: [
           {
@@ -292,7 +288,6 @@ describe("Game API Handlers", () => {
       const createRequest: GameCreateRequest = {
         gameId: "version-test-game",
         gameTitle: "버전 테스트 게임",
-        gameCreatorEmail: "test@example.com",
         gameThumbnailUrl: "https://example.com/thumbnail.jpg",
         questions: [
           {
@@ -336,7 +331,6 @@ describe("Game API Handlers", () => {
       const createRequest: GameCreateRequest = {
         gameId: "delete-test-game",
         gameTitle: "삭제 테스트 게임",
-        gameCreatorEmail: "test@example.com",
         gameThumbnailUrl: "https://example.com/thumbnail.jpg",
         questions: [
           {
@@ -389,7 +383,6 @@ describe("Game API Handlers", () => {
       const createRequest: GameCreateRequest = {
         gameId: "share-test-game",
         gameTitle: "공유 테스트 게임",
-        gameCreatorEmail: "test@example.com",
         gameThumbnailUrl: "https://example.com/thumbnail.jpg",
         questions: [
           {
@@ -431,7 +424,6 @@ describe("Game API Handlers", () => {
       const createRequest: GameCreateRequest = {
         gameId: "unshare-test-game",
         gameTitle: "공유 해제 테스트 게임",
-        gameCreatorEmail: "test@example.com",
         gameThumbnailUrl: "https://example.com/thumbnail.jpg",
         questions: [
           {

--- a/service/app/src/mocks/handlers/game.ts
+++ b/service/app/src/mocks/handlers/game.ts
@@ -100,13 +100,6 @@ export const gameHandlers = [
       const endIndex = startIndex + pageSize
       const paginatedGames = sortedGames.slice(startIndex, endIndex)
 
-      console.log("MSW: /user/me/games - Total games:", myGames.length)
-      console.log(
-        "MSW: /user/me/games - Paginated games:",
-        paginatedGames.length,
-      )
-      console.log("MSW: /user/me/games - First game:", paginatedGames[0])
-
       return HttpResponse.json({
         result: "SUCCESS",
         error: null,

--- a/service/app/src/mocks/utils/gameHandlers.ts
+++ b/service/app/src/mocks/utils/gameHandlers.ts
@@ -31,13 +31,13 @@ export const validateSessionCookie = (cookieHeader: string | null): boolean => {
 }
 
 export const validateGameCreateFields = (body: GameCreateRequest): boolean => {
-  const { gameId, gameTitle, gameCreatorEmail, questions } = body
-  return !!(gameId && gameTitle && gameCreatorEmail && questions)
+  const { gameId, gameTitle, questions } = body
+  return !!(gameId && gameTitle && questions)
 }
 
 export const validateGameUpdateFields = (body: GameUpdateRequest): boolean => {
-  const { gameTitle, gameCreatorEmail, questions, version } = body
-  return !!(gameTitle && gameCreatorEmail && questions && version !== undefined)
+  const { gameTitle, questions, version } = body
+  return !!(gameTitle && questions && version !== undefined)
 }
 
 export const validateQuestionsArray = (

--- a/shared/design/src/components/gameCard/index.tsx
+++ b/shared/design/src/components/gameCard/index.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import { forwardRef } from "react"
 
-import { Edit, MoreDot, Trash, Upload } from "../../icons"
+import { Edit, MoreDot, Trash, Unshare } from "../../icons"
 import { cn } from "../../utils/cn"
 import { SecondaryPlainIconButton } from "../button"
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuRoot, DropdownMenuTrigger } from "../menu"
@@ -220,8 +220,10 @@ export const GameCard = forwardRef<HTMLDivElement, GameCardProps>(
                   e.stopPropagation()
                   props.onShare?.()
                 }}>
-                  <Upload />
-                  <span className="text-text-interactive-secondary">게임 공유</span>
+                  <Unshare />
+                  <span className="text-text-interactive-secondary">
+                    {shared ? "공유취소" : "게임 공유"}
+                  </span>
                 </DropdownMenuItem>
                 <DropdownMenuItem type="icon" onClick={(e) => {
                   e.stopPropagation()

--- a/shared/lib/fetchClient.ts
+++ b/shared/lib/fetchClient.ts
@@ -35,7 +35,6 @@ fetchClient.addResponseInterceptor(
 if (process.env.NODE_ENV === "development") {
   fetchClient.addRequestInterceptor(async (url, options) => {
     console.log("🚀 Request:", url, options)
-    console.log("🍪 Cookies in request:", document.cookie)
     return { url, options }
   })
 


### PR DESCRIPTION
## 📝 설명

게임 수정 기능을 구현했습니다. 기존에는 게임 수정 버튼을 눌러도 편집창에 기존 게임 정보가 반영되지 않았던 문제를 해결하고, 게임 수정 API 호출이 제대로 작동하도록 구현했습니다.

## 🛠️ 주요 변경 사항

- 게임 수정 상태 관리 구조 추가 b792165
- 게임 수정 페이지에서 기존 게임 데이터 로딩 기능 추가 ad19297
- API 타입 정의 업데이트 29d1834
- 게임 수정 API 함수 추가 ca4d8b6
- 게임 저장/수정 로직 업데이트 6153606

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - URL의 gameId로 기존 게임을 불러와 생성 화면을 자동 초기화합니다(제목·문항·이미지·버전 포함).
  - 저장 버튼이 상황에 따라 “게임 저장”/“게임 수정”으로 표시되며, 기존 게임은 수정 모드로 업데이트됩니다.
  - 새 이미지 없이도 기존 이미지를 유지한 채 게임 정보를 업데이트할 수 있습니다.
  - 게임 버전 정보를 관리해 수정 시 버전을 함께 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->