### PR TITLE
아바타 이미지 통일

### DIFF
--- a/service/app/src/app/dashboard/__tests__/dashboard.spec.ts
+++ b/service/app/src/app/dashboard/__tests__/dashboard.spec.ts
@@ -291,7 +291,7 @@ test.describe("대시보드 E2E 테스트 - 기본 UI 확인", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
-          profileImageUrl: "/exampleThumbnail.jpg",
+          profileImageUrl: "/avatar.svg",
           nickname: "testUser",
           email: "test@example.com",
         }),
@@ -320,7 +320,7 @@ test.describe("대시보드 E2E 테스트 - 네비게이션 기능", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
-          profileImageUrl: "/exampleThumbnail.jpg",
+          profileImageUrl: "/avatar.svg",
           nickname: "testUser",
           email: "test@example.com",
         }),
@@ -351,7 +351,7 @@ test.describe("대시보드 E2E 테스트 - 게임 카드 기능", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
-          profileImageUrl: "/exampleThumbnail.jpg",
+          profileImageUrl: "/avatar.svg",
           nickname: "testUser",
           email: "test@example.com",
         }),
@@ -393,7 +393,7 @@ test.describe("대시보드 E2E 테스트 - 게임 옵션 메뉴", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
-          profileImageUrl: "/exampleThumbnail.jpg",
+          profileImageUrl: "/avatar.svg",
           nickname: "testUser",
           email: "test@example.com",
         }),
@@ -426,7 +426,7 @@ test.describe("대시보드 E2E 테스트 - Alert 팝업", () => {
       localStorage.setItem(
         "auth_user",
         JSON.stringify({
-          profileImageUrl: "/exampleThumbnail.jpg",
+          profileImageUrl: "/avatar.svg",
           nickname: "testUser",
           email: "test@example.com",
         }),

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -30,7 +30,7 @@ export default function DashboardPage() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [_searchQuery, _setSearchQuery] = useState("")
-  const { user, isLoading: _authLoading, isAuthenticated, logout } = useAuth()
+  const { isLoading: _authLoading, isAuthenticated, logout } = useAuth()
   const [listButton, setListButton] = useState(false)
 
   const {
@@ -207,13 +207,13 @@ export default function DashboardPage() {
             className="flex size-[42px] cursor-pointer items-center justify-center rounded-full bg-gray-300"
             onClick={handleAvatarClick}
           >
-            <Image
-              src={user?.profileImageUrl || "/avatar.svg"}
-              alt="사용자 아바타"
-              className="size-full rounded-full"
-              width={42}
-              height={42}
-            />
+                <Image
+                  src="/avatar.svg"
+                  alt="사용자 아바타"
+                  className="size-full rounded-full"
+                  width={42}
+                  height={42}
+                />
           </div>
           {listButton && (
             <div className="absolute right-0 top-full z-10 mt-2">

--- a/service/app/src/app/games/page.tsx
+++ b/service/app/src/app/games/page.tsx
@@ -132,13 +132,13 @@ export default function GamesPage() {
         <>
           <div className="flex items-center gap-2">
             <div className="flex size-[42px] items-center justify-center rounded-full bg-gray-300">
-              <Image
-                src={user?.profileImageUrl || "/avatar.svg"}
-                alt="사용자 아바타"
-                className="size-full rounded-full"
-                width={42}
-                height={42}
-              />
+                <Image
+                  src="/avatar.svg"
+                  alt="사용자 아바타"
+                  className="size-full rounded-full"
+                  width={42}
+                  height={42}
+                />
             </div>
             <span className="text-sm font-medium text-text-primary">
               {user?.nickname}

--- a/service/app/src/mocks/data/auth.ts
+++ b/service/app/src/mocks/data/auth.ts
@@ -1,7 +1,7 @@
 import { KakaoLoginData, KakaoLoginResponse } from "@/entities/auth/model/auth"
 
 const mockKakaoLoginData: KakaoLoginData = {
-  profileImageUrl: "/exampleThumbnail.jpg",
+  profileImageUrl: "/avatar.svg",
   nickname: "testUser",
   email: "test@example.com",
 }

--- a/service/app/src/widgets/HomeNavigation.tsx
+++ b/service/app/src/widgets/HomeNavigation.tsx
@@ -21,7 +21,6 @@ interface HomeNavigationProps {
 export const HomeNavigation = ({ className = "" }: HomeNavigationProps) => {
   const router = useRouter()
   const {
-    user,
     isLoading: authLoading,
     isAuthenticated,
     logout,
@@ -119,7 +118,7 @@ export const HomeNavigation = ({ className = "" }: HomeNavigationProps) => {
                   aria-haspopup="true"
                 >
                   <Image
-                    src={user?.profileImageUrl || "/avatar.svg"}
+                    src="/avatar.svg"
                     alt="사용자 아바타"
                     className="size-full rounded-full"
                     width={42}


### PR DESCRIPTION
## 📝 설명

아바타 이미지를 기본제공되는 avatar.svg로 통일했습니다.

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 로그인 상태와 관계없이 아바타가 항상 기본 이미지로 표시되도록 통일
- 테스트
  - 대시보드 관련 테스트에서 아바타 경로를 기본 이미지로 업데이트
- 자잘한 작업
  - 모의 로그인 데이터의 프로필 이미지 경로를 기본 이미지로 변경
- 리팩터링
  - 대시보드, 게임, 홈 내비게이션에서 사용자 프로필 이미지 의존성 제거 및 정적 아바타로 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->