### PR TITLE
feat(create): add route guard

### DIFF
--- a/service/app/playwright.config.ts
+++ b/service/app/playwright.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   testMatch: "**/*.spec.ts",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 0 : 0,
+  workers: process.env.CI ? 2 : undefined,
   reporter: "html",
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",

--- a/service/app/src/app/create/layout.tsx
+++ b/service/app/src/app/create/layout.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+import { useAuth } from "@/entities/auth"
+
+export default function ClientLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { isAuthenticated, isLoading } = useAuth()
+  const router = useRouter()
+
+  console.log(isAuthenticated, isLoading)
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace("/login")
+    }
+  }, [isAuthenticated, isLoading, router])
+
+  if (isLoading) return null
+  if (!isAuthenticated) return null
+
+  return <div>{children}</div>
+}

--- a/service/app/src/app/create/layout.tsx
+++ b/service/app/src/app/create/layout.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import React, { useEffect } from "react"
 
 import { useAuth } from "@/entities/auth"
 
@@ -12,8 +12,6 @@ export default function ClientLayout({
 }) {
   const { isAuthenticated, isLoading } = useAuth()
   const router = useRouter()
-
-  console.log(isAuthenticated, isLoading)
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {

--- a/service/app/src/entities/game/ui/components/fileUploadArea.tsx
+++ b/service/app/src/entities/game/ui/components/fileUploadArea.tsx
@@ -43,18 +43,17 @@ export function FileUploadArea() {
   }
 
   return (
-    <FileUpload onValueChange={handleFileUpload}>
+    <FileUpload onAccept={handleFileUpload}>
       <Dropzone className="flex h-[632px] w-[577px] flex-col items-center justify-center gap-[22px] p-[10px]">
         {hasImage ? (
-          <div className="group relative mt-4 h-[500px] w-[577px]">
+          <div className="group relative size-full">
             <Image
               src={
                 selectedQuestion.imageUrl || selectedQuestion.previewImageUrl!
               }
               alt="업로드된 이미지"
-              width={577}
-              height={500}
-              className="size-full rounded-[10px] object-cover"
+              fill
+              className="rounded-[10px] object-cover"
             />
             <div className="absolute inset-0 flex items-center justify-center rounded-[10px] bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
               <FileUploadTrigger asChild>

--- a/service/app/src/entities/game/ui/components/questionList.tsx
+++ b/service/app/src/entities/game/ui/components/questionList.tsx
@@ -9,7 +9,7 @@ export function QuestionList() {
   const { state, actions, getQuestionSelectors } = useGameCreationContext()
 
   return (
-    <div className="flex w-[400px] flex-col items-center bg-gray-50 p-[25px_25px_0_25px]">
+    <div className="flex h-[calc(100vh-110px)] w-[400px] flex-col items-center overflow-y-auto bg-gray-50 p-[25px_25px_0_25px]">
       <div className="flex w-[350px] flex-col items-start gap-6">
         {state.questions.map((question) => {
           const questionSelectors = getQuestionSelectors(question.id)


### PR DESCRIPTION
## 📝 설명

- create 페이지의 route guard로직 추가
- create 페이지의 스타일 관련 변경
- playwright worker를 2로 변경

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 생성 페이지 진입 시 인증 상태를 확인해 미인증 사용자는 자동으로 로그인 페이지로 이동합니다.
  - 로딩 중이거나 인증되지 않은 경우 콘텐츠를 숨겨 화면 깜빡임을 방지합니다.

- 개선사항
  - 이미지 업로드 영역이 고정 크기에서 컨테이너에 맞게 채워지는 반응형 방식으로 변경되었습니다.
  - 업로드 컴포넌트의 파일 처리 인터페이스가 변경되어 파일 수락 방식이 업데이트되었습니다.
  - 질문 목록에 높이 제약과 세로 스크롤이 추가되어 긴 목록 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->