### PR TITLE
네비게이션 관련 스타일 버그 해결

### DIFF
--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -4,7 +4,6 @@ import {
   PrimaryBoxButton,
   SecondaryOutlineBoxButton,
 } from "@shared/design/src/components/button"
-import { Navigation } from "@shared/design/src/components/navigation"
 import { ThemeToggle } from "@shared/design/src/components/themeToggle"
 import { Add } from "@shared/design/src/icons"
 import { useQueryClient } from "@tanstack/react-query"

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -255,13 +255,21 @@ export default function DashboardPage() {
 
   return (
     <main className="min-h-screen bg-background-primary">
-      <Navigation
-        type="title"
-        playGame={false}
-        leftContent={leftContent}
-        centerContent={centerContent}
-        rightContent={rightContent}
-      />
+      <nav className="flex h-[110px] w-full items-center justify-between bg-background-tertiary">
+        <div className="flex w-[420px] items-center gap-2.5 px-10">
+          {leftContent}
+        </div>
+
+        <div className="flex w-[1080px] justify-center">
+          {centerContent}
+        </div>
+
+        <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+          <div className="flex items-center justify-end gap-4 px-10">
+            {rightContent}
+          </div>
+        </div>
+      </nav>
       <div className="flex w-full flex-col items-center gap-[45px] pt-[40px]">
         <GameLibraryGrid
           games={games}

--- a/service/app/src/app/games/__tests__/library.spec.ts
+++ b/service/app/src/app/games/__tests__/library.spec.ts
@@ -51,7 +51,7 @@ class LibraryPage {
     this.kakaoLoginButton = page.getByRole("button", { name: "카카오 간편 로그인" })
 
     // 로그인 상태에서 추가되는 요소들
-    this.avatarButton = page.getByRole("button", { name: "사용자 아바타" })
+    this.avatarButton = page.getByRole("button", { name: /사용자 메뉴/ })
     this.logoutButton = page.getByRole("button", { name: "로그아웃" })
 
     // 게임 미리 보기 팝업 요소들

--- a/service/app/src/app/games/__tests__/library.spec.ts
+++ b/service/app/src/app/games/__tests__/library.spec.ts
@@ -182,6 +182,7 @@ class LibraryPage {
     await expect(this.createGameButton).toBeVisible()
     await expect(this.kakaoLoginButton).not.toBeVisible()
     await expect(this.avatarButton).toBeVisible()
+    await this.avatarButton.click()
     await expect(this.logoutButton).toBeVisible()
   }
 

--- a/service/app/src/app/games/__tests__/library.spec.ts
+++ b/service/app/src/app/games/__tests__/library.spec.ts
@@ -35,6 +35,7 @@ class LibraryPage {
   readonly startGameButton: Locator
   readonly avatarButton: Locator
   readonly logoutButton: Locator
+  readonly userMenu: Locator
 
   constructor(page: Page) {
     this.page = page
@@ -52,7 +53,8 @@ class LibraryPage {
 
     // 로그인 상태에서 추가되는 요소들
     this.avatarButton = page.getByRole("button", { name: /사용자 메뉴/ })
-    this.logoutButton = page.getByRole("button", { name: "로그아웃" })
+    this.logoutButton = page.getByRole("menuitem", { name: "로그아웃" })
+    this.userMenu = page.locator('[data-user-menu]')
 
     // 게임 미리 보기 팝업 요소들
     this.gamePreviewDialog = page.getByRole("dialog")
@@ -183,6 +185,8 @@ class LibraryPage {
     await expect(this.kakaoLoginButton).not.toBeVisible()
     await expect(this.avatarButton).toBeVisible()
     await this.avatarButton.click()
+    await this.page.waitForTimeout(100)
+    await expect(this.userMenu).toBeVisible()
     await expect(this.logoutButton).toBeVisible()
   }
 

--- a/service/app/src/app/games/page.tsx
+++ b/service/app/src/app/games/page.tsx
@@ -22,7 +22,7 @@ import { GamePreview } from "@/entities/game/ui/components/gamePreview"
 export default function GamesPage() {
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useState("")
-  const { user, isLoading: authLoading, isAuthenticated, logout } = useAuth()
+  const { user, isLoading: authLoading, isAuthenticated, login, logout } = useAuth()
   const { setTheme, resolvedTheme } = useTheme()
   const [listButton, setListButton] = useState(false)
   const [mounted, setMounted] = useState(false)
@@ -97,8 +97,16 @@ export default function GamesPage() {
   }
 
   const handleLogin = async () => {
-    console.log("Login clicked")
-    router.push("/login")
+    if (process.env.NODE_ENV === "development") {
+      try {
+        await login("someValidCode")
+      } catch (error) {
+        console.error("Login error:", error)
+      }
+      return
+    }
+
+    window.location.href = "/login"
   }
 
   const handleThemeToggle = () => {

--- a/service/app/src/app/games/page.tsx
+++ b/service/app/src/app/games/page.tsx
@@ -24,6 +24,7 @@ export default function GamesPage() {
   const [searchQuery, setSearchQuery] = useState("")
   const { user, isLoading: authLoading, isAuthenticated, logout } = useAuth()
   const { setTheme, resolvedTheme } = useTheme()
+  const [listButton, setListButton] = useState(false)
   const [mounted, setMounted] = useState(false)
 
   const { games, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
@@ -108,6 +109,29 @@ export default function GamesPage() {
     router.push("/")
   }
 
+  const handleAvatarClick = () => {
+    setListButton(!listButton)
+  }
+
+  const handleLogoutClick = () => {
+    logout()
+    setListButton(false)
+  }
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element
+      if (listButton && !target.closest('[data-user-menu]')) {
+        setListButton(false)
+      }
+    }
+
+    if (listButton) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [listButton])
+
   const leftContent = (
     <button
       className="flex h-[60px] w-[268px] cursor-pointer items-center justify-center p-3.5 focus:outline-none focus:ring-2 focus:ring-border-interactive-primary focus:ring-offset-2 focus:ring-offset-background-tertiary"
@@ -142,9 +166,17 @@ export default function GamesPage() {
       {isAuthenticated ? (
         <>
           <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-text-primary">
+              {user?.nickname}
+            </span>
+          </div>
+          <div className="relative" data-user-menu>
             <button
-              className="flex size-[42px] items-center justify-center rounded-full bg-gray-300 focus:outline-none focus:ring-2 focus:ring-border-interactive-primary focus:ring-offset-2 focus:ring-offset-background-tertiary"
-              aria-label="사용자 아바타"
+              className="flex size-[42px] cursor-pointer items-center justify-center rounded-full bg-gray-300 focus:outline-none focus:ring-2 focus:ring-border-interactive-primary focus:ring-offset-2 focus:ring-offset-background-tertiary"
+              onClick={handleAvatarClick}
+              aria-label={`사용자 메뉴 ${listButton ? '닫기' : '열기'}`}
+              aria-expanded={listButton}
+              aria-haspopup="true"
               tabIndex={0}
             >
               <Image
@@ -155,17 +187,25 @@ export default function GamesPage() {
                 height={42}
               />
             </button>
-            <span className="text-sm font-medium text-text-primary">
-              {user?.nickname}
-            </span>
+            {listButton && (
+              <div
+                className="absolute right-0 top-full z-10 mt-2"
+                role="menu"
+                aria-label="사용자 메뉴"
+              >
+                <SecondaryOutlineBoxButton
+                  size="md"
+                  onClick={handleLogoutClick}
+                  className="whitespace-nowrap"
+                  role="menuitem"
+                  aria-label="로그아웃"
+                  tabIndex={0}
+                >
+                  로그아웃
+                </SecondaryOutlineBoxButton>
+              </div>
+            )}
           </div>
-          <SecondaryOutlineBoxButton 
-            size="md" 
-            onClick={logout}
-            aria-label="로그아웃"
-          >
-            로그아웃
-          </SecondaryOutlineBoxButton>
         </>
       ) : (
         <SecondaryOutlineBoxButton


### PR DESCRIPTION
## 📝 설명

<!--
    작업한 내용을 요약해서 작성
 -->

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 게임 목록 헤더에 아바타 기반 사용자 메뉴 드롭다운 추가; 외부 클릭으로 닫힘. 로그아웃을 드롭다운 항목으로 이동. 닉네임을 아바타 옆에 항상 표시. 접근성 라벨과 상태 표시 개선.
- 리팩터
  - 대시보드 헤더를 좌·중·우 3열 고정 레이아웃(고정 높이 및 배경 포함)으로 재구성.
- 테스트
  - 사용자 메뉴 흐름에 맞춰 테스트 업데이트(아바타 선택자 및 상호작용 검증 변경).
- 잡무(Chores)
  - 인증 훅의 공개 반환값에 로그인 함수(login(code: string) => Promise<void>) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->