### PR TITLE
500페이지 로직 수정

### DIFF
--- a/.cursor/rules/guides/playwright-convention.mdc
+++ b/.cursor/rules/guides/playwright-convention.mdc
@@ -20,6 +20,96 @@ You write concise, technical TypeScript and technical JavaScript codes with accu
 - Use `page.getByTestId` whenever `data-testid` is defined on an element or container
 - Reuse Playwright locators by using variables or constants for commonly used elements
 
+### Accessibility-First Locator Examples
+
+```typescript
+// ✅ Accessibility role-based - matches real user experience
+const buyButton = page.getByRole('button', { name: '구매하기' })
+const loginDialog = page.getByRole('alertdialog', { name: '로그인' })
+const productList = page.getByRole('list', { name: '상품 목록' })
+const productForm = page.getByRole('form', { name: '상품 주문' })
+
+// ❌ Avoid CSS selectors - dependent on implementation details
+const buyButton = page.locator('.btn-primary[data-action="buy"]')
+```
+
+## Common Anti-Patterns to Avoid
+
+### Anti-Pattern 1: Role Nesting Issues
+
+```html
+<!-- ❌ Role gets overwritten -->
+<Link role='listitem' href='/products/1'>Product Name</Link>
+
+<!-- ✅ Proper role separation -->
+<li role='listitem'>
+  <Link href='/products/1'>Product Name</Link>
+</li>
+```
+
+```typescript
+// Test code
+await page.getByRole('list').getByRole('link', { name: 'Product Name' }).click()
+```
+
+### Anti-Pattern 2: Confusing textContent with accessible name
+
+```typescript
+// ❌ Fails - alert doesn't use textContent as accessible name
+await expect(page.getByRole('alert', { name: 'Error message' })).toBeVisible()
+
+// ✅ Use filter for text content
+await expect(page.getByRole('alert').filter({ hasText: 'Error message' })).toBeVisible()
+
+// ✅ Or use explicit aria-label
+// <div role='alert' aria-label='Error notification'>{message}</div>
+await expect(page.getByRole('alert', { name: 'Error notification' })).toBeVisible()
+```
+
+### Anti-Pattern 3: Using waitForTimeout
+
+```typescript
+// ❌ Fixed timeout - slow and flaky
+await page.waitForTimeout(3000)
+const items = await page.getByRole('listitem').all()
+expect(items).toHaveLength(12)
+
+// ✅ Auto-retrying assertion - waits until condition is met
+await expect(page.getByRole('listitem')).toHaveCount(12)
+```
+
+## User Scenario Testing
+
+### Integrated Scenario Pattern
+
+Minimize external state dependencies by testing create-use-delete in a single flow:
+
+```typescript
+// ✅ Integrated scenario - independent of external state
+test('Complete cart workflow', async ({ page }) => {
+  await setupLogin(page)
+
+  // Add item (regardless of existing cart state)
+  await page.goto('/products/123')
+  await page.getByRole('button', { name: 'Add to Cart' }).click()
+
+  // Navigate to cart
+  await page.getByRole('alertdialog').getByRole('button', { name: 'Go to Cart' }).click()
+
+  // Clear all items (regardless of quantity)
+  await page.getByRole('button', { name: 'Clear All' }).click()
+  await page.getByRole('alertdialog').getByRole('button', { name: 'Confirm' }).click()
+
+  // Verify empty state
+  await expect(page.getByText('Your cart is empty')).toBeVisible()
+})
+
+// ❌ Separate tests - dependent on external state
+test('Empty cart display', async ({ page }) => {
+  // Assumes cart is empty... but is it really?
+})
+```
+
 ## Configuration & Setup
 
 - Use the `playwright.config.ts` file for global configuration and environment setup
@@ -30,9 +120,57 @@ You write concise, technical TypeScript and technical JavaScript codes with accu
 ## Assertions & Timing
 
 - Prefer to use web-first assertions (`toBeVisible`, `toHaveText`, etc.) whenever possible
+- **Never use `waitForTimeout()`** - always use auto-retrying web-first assertions
+- Use auto-retrying assertions: `toHaveCount()` automatically retries until condition is met, unlike `toHaveLength()` with pre-fetched elements
 - Use `expect` matchers for assertions (`toEqual`, `toContain`, `toBeTruthy`, `toHaveLength`, etc.) that can be used to assert any conditions and avoid using `assert` statements
 - Avoid hardcoded timeouts
 - Use `page.waitFor` with specific conditions or events to wait for elements or states
+
+### Auto-Retrying vs Non-Retrying Assertions
+
+```typescript
+// ❌ Non-retrying - checks once and fails immediately
+const items = await page.getByRole('listitem').all()
+expect(items).toHaveLength(12)
+
+// ✅ Auto-retrying - retries until condition is met
+await expect(page.getByRole('listitem')).toHaveCount(12)
+```
+
+## External Dependencies Management
+
+### Controllable Side Effects
+
+Combine create and delete operations in a single test to reduce state dependencies
+
+### User State Setup
+
+```typescript
+// User type setup utility
+const setupUser = async (page: Page, userType: 'guest' | 'member' | 'premium') => {
+  const testAccounts = {
+    guest: null,
+    member: 'test-member@example.com',
+    premium: 'test-premium@example.com'
+  }
+
+  if (testAccounts[userType]) {
+    await setupLogin(page, testAccounts[userType])
+  }
+}
+
+// Usage in tests
+test('Premium member purchase', async ({ page }) => {
+  await setupUser(page, 'premium')
+  // Purchase flow...
+})
+```
+
+### API Mocking Guidelines
+
+- Prioritize real API usage over mocking
+- Mock only uncontrollable external services (payment, email)
+- Consider test environment setup for external dependencies
 
 ## Page Object Model (POM) Pattern
 
@@ -56,31 +194,30 @@ export class GameSetupPage {
 
   constructor(page: Page) {
     this.page = page
-    // Initialize locators using semantic selectors
+    // Use accessibility role-based locators
     this.addTeamButton = page.getByRole("button", { name: "참가자 및 팀 추가하기" })
-    this.teamInputs = page.locator('input[name^="team-"]')
-    this.deleteButtons = page.getByRole("button", { name: "clear input" })
+    this.teamInputs = page.getByRole("textbox", { name: /팀 이름/ })
+    this.deleteButtons = page.getByRole("button", { name: "삭제" })
   }
 
   // Navigation methods
   async goto(gameId: string = "1") {
-    await this.page.goto(`http://localhost:3000/game/${gameId}/setup`)
-    await this.page.waitForLoadState("networkidle")
+    await this.page.goto(`/game/${gameId}/setup`)
   }
 
   // Action methods
-  async addTeam(): Promise<void> {
+  async addTeam(){
     await expect(this.addTeamButton).toBeEnabled()
     await this.addTeamButton.click()
   }
 
   // Getter methods
-  async getTeamCount(): Promise<number> {
+  async getTeamCount() {
     return await this.teamInputs.count()
   }
 
   // Assertion methods
-  async expectTeamToBeVisible(teamName: string): Promise<void> {
+  async expectTeamToBeVisible(teamName: string) {
     await expect(this.page.getByText(teamName)).toBeVisible()
   }
 }
@@ -90,9 +227,11 @@ export class GameSetupPage {
 
 - **Single Responsibility**: Each page object should represent one page or component
 - **Encapsulation**: Hide implementation details behind meaningful method names
-- **Semantic Locators**: Use role-based and semantic selectors within page objects
-- **Method Naming**: Use action verbs (add, delete, change) and assertion patterns (expect*)
-- **Return Types**: Action methods can return void, getter methods return data, assertion methods use Promise<void>
+- **Accessibility-First Locators**: Use role-based and semantic selectors within page objects
+- **Selective Locator Declaration**: Focus on selector-based approach, declare only necessary selectors
+- **Method Naming**: Use action verbs (add, delete, change) and assertion patterns (expect\*)
+- **No Explicit Return Types**: Let TypeScript infer return types automatically
+- Follow the guidance and best practices described on "https://playwright.dev/docs/writing-tests"
 
 #### File Organization
 
@@ -108,22 +247,26 @@ __tests__/
 ### POM Best Practices
 
 #### Constructor Pattern
+
 - Initialize `page` parameter and all locators in constructor
 - Use `readonly` for immutable properties
 - Prefer semantic selectors over CSS/XPath selectors
 
 #### Method Categories
+
 - **Navigation**: `goto()`, `navigateToSection()`
 - **Actions**: `addTeam()`, `deleteItem()`, `fillForm()`
 - **Getters**: `getTeamCount()`, `getErrorMessage()`
 - **Assertions**: `expectTeamVisible()`, `expectButtonDisabled()`
 
 #### Error Handling
+
 - Include built-in assertions in action methods when appropriate
 - Provide meaningful error messages through page object methods
 - Handle common wait conditions within page object methods
 
 #### Test Integration
+
 ```typescript
 test.describe("게임 설정 - 팀 관리", () => {
   let gameSetupPage: GameSetupPage
@@ -144,6 +287,5 @@ test.describe("게임 설정 - 팀 관리", () => {
 
 - Ensure tests run reliably in parallel without shared state conflicts
 - Avoid commenting on the resulting code
-- Focus on critical user paths, maintaining tests that are stable, maintainable, and reflect real user behavior
-- **Consider implementing POM pattern** for complex pages with multiple interactions
-- Follow the guidance and best practices described on "https://playwright.dev/docs/writing-tests"
+- Write tests that reflect real user behavior using accessibility-first locators
+- Use integrated user scenarios to minimize external dependencies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "eslint.format.enable": true,
-  "editor.formatOnSave": true,
+  // "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,10 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.format.enable": true,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^9",
+    "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "playwright": "^1.53.1",
     "prettier": "^3.5",

--- a/service/app/src/app/game/[gameId]/error.tsx
+++ b/service/app/src/app/game/[gameId]/error.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { PrimaryBoxButton } from "@shared/design/src/components/button"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const router = useRouter()
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <PrimaryBoxButton onClick={() => router.replace("./setup")}>
+        Try again
+      </PrimaryBoxButton>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/play/__tests__/game-play.spec.ts
+++ b/service/app/src/app/game/[gameId]/play/__tests__/game-play.spec.ts
@@ -66,20 +66,21 @@ test.describe("게임 진행 - 두 번째 문제 플로우", () => {
   test("'이전 문제' 클릭 시 이전 라운드로 이동하고 진행률이 감소한다", async ({
     page,
   }) => {
-    // 2번 문제로 이동
+    // 1번 → 2번 문제로 이동하고 URL 변경 대기
     await pageObj.goToNextQuestion()
+    await page.waitForURL(/\?q=2/, { timeout: 1000 })
+
+    // 2번 → 3번 문제로 이동하고 URL 변경 대기
+    await pageObj.goToNextQuestion()
+    await page.waitForURL(/\?q=3/, { timeout: 1000 })
+
+    // 진행률 측정 후 이전 문제로 이동
     const before = await pageObj.getProgressValue()
-
     await pageObj.goToPrevQuestion()
+    await page.waitForURL(/\?q=2/, { timeout: 1000 })
+
     const after = await pageObj.getProgressValue()
-
-    await expect(page).toHaveURL(/\?q=1/)
-
-    expect(before).not.toBeNull()
-    expect(after).not.toBeNull()
-    if (before !== null && after !== null) {
-      expect(after).toBeLessThanOrEqual(before)
-    }
+    expect(after).toBeLessThanOrEqual(before!)
   })
 
   //실제 문제 개수를 알지 못하기 때문에, 정확한 value 측정보다는 비교 연산으로 테스트 진행
@@ -91,10 +92,7 @@ test.describe("게임 진행 - 두 번째 문제 플로우", () => {
     await expect(page).toHaveURL(/\?q=2/)
 
     const after = await pageObj.getProgressValue()
-    expect(before).not.toBeNull()
-    expect(after).not.toBeNull()
-    if (before !== null && after !== null) {
-      expect(after).toBeGreaterThanOrEqual(before)
-    }
+
+    expect(after).toBeGreaterThanOrEqual(before!)
   })
 })

--- a/service/app/src/app/game/[gameId]/play/__tests__/gamePlayPOM.ts
+++ b/service/app/src/app/game/[gameId]/play/__tests__/gamePlayPOM.ts
@@ -55,81 +55,80 @@ export class GamePlayPOM {
     this.exitDialogCancelButton = page.getByRole("button", { name: "아니요" })
   }
 
-  async goto(gameId: string = "1", round?: number): Promise<void> {
+  async goto(gameId: string = "1", round?: number) {
     const search = round ? `?q=${round}` : ""
     await this.page.goto(`game/${gameId}/play${search}`)
-    await this.page.waitForLoadState("networkidle")
   }
 
-  async clickHomeLogo(): Promise<void> {
+  async clickHomeLogo() {
     await this.homeLogoImage.click()
   }
 
-  async goToPrevQuestion(): Promise<void> {
+  async goToPrevQuestion() {
     await this.prevQuestionButton.click()
   }
 
-  async goToNextQuestion(): Promise<void> {
+  async goToNextQuestion() {
     await this.nextQuestionButton.click()
   }
 
-  async clickExitIcon(): Promise<void> {
+  async clickExitIcon() {
     await this.exitIconButton.click()
   }
 
-  async getProgressValue(): Promise<number | null> {
+  async getProgressValue() {
     const value = await this.progressbar.getAttribute("aria-valuenow")
     return value ? Number(value) : null
   }
 
-  async toggleScoreboard(): Promise<void> {
+  async toggleScoreboard() {
     await this.scoreboardToggleButton.click()
   }
 
   // 팀 관련 접근성 셀렉터 기반
-  teamCard(teamName: string): Locator {
+  teamCard(teamName: string) {
     return this.page.getByRole("group", { name: `${teamName} 점수 카드` })
   }
 
-  teamScoreLabel(teamName: string): Locator {
+  teamScoreLabel(teamName: string) {
     return this.page.getByLabel(`${teamName} 현재 점수`)
   }
 
-  teamDecreaseButton(teamName: string): Locator {
+  teamDecreaseButton(teamName: string) {
     return this.page.getByRole("button", { name: `${teamName} 점수 감소` })
   }
 
-  teamIncreaseButton(teamName: string): Locator {
+  teamIncreaseButton(teamName: string) {
     return this.page.getByRole("button", { name: `${teamName} 점수 증가` })
   }
 
-  async increaseScore(teamName: string, times: number = 1): Promise<void> {
+  async increaseScore(teamName: string, times: number = 1) {
     const inc = this.teamIncreaseButton(teamName)
     for (let i = 0; i < times; i++) {
       await inc.click()
     }
   }
 
-  async decreaseScore(teamName: string, times: number = 1): Promise<void> {
+  async decreaseScore(teamName: string, times: number = 1) {
     const dec = this.teamDecreaseButton(teamName)
     for (let i = 0; i < times; i++) {
       await dec.click()
     }
   }
 
-  async expectTeamScore(teamName: string, expectedText: string): Promise<void> {
+  async expectTeamScore(teamName: string, expectedText: string) {
     await expect(this.teamScoreLabel(teamName)).toHaveText(expectedText)
   }
 
-  async getQuestionText(): Promise<string> {
+  async getQuestionText() {
     return (await this.questionHeading.textContent())?.trim() ?? ""
   }
 
-  async isQuestionImageVisible(): Promise<boolean> {
+  async isQuestionImageVisible() {
     return await this.questionImage.isVisible()
   }
 
-  async showAnswerAndGetText(): Promise<string> {
+  async showAnswerAndGetText() {
     await this.showAnswerButton.click()
     const answerButton = this.page
       .getByRole("button")
@@ -140,7 +139,7 @@ export class GamePlayPOM {
     return answerText
   }
 
-  async hideAnswer(): Promise<void> {
+  async hideAnswer() {
     const answerButton = this.page
       .getByRole("button")
       .filter({ hasNotText: "정답 보기" })
@@ -149,11 +148,11 @@ export class GamePlayPOM {
     await expect(this.showAnswerButton).toBeVisible()
   }
 
-  async confirmExit(): Promise<void> {
+  async confirmExit() {
     await this.exitDialogConfirmButton.click()
   }
 
-  async cancelExit(): Promise<void> {
+  async cancelExit() {
     await this.exitDialogCancelButton.click()
   }
 }

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -1,0 +1,58 @@
+import {
+  PrimaryBoxButton,
+  SecondaryOutlineBoxButton,
+} from "@ject-5-fe/design/components/button"
+import Image from "next/image"
+import { useState } from "react"
+
+import type { GameQuestion } from "@/entities/game/model"
+
+interface GamePlayContentProps {
+  currentQuestion: GameQuestion
+}
+
+export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
+  const [showAnswer, setShowAnswer] = useState(false)
+
+  return (
+    <div className="flex w-full flex-1 flex-col items-center justify-center">
+      {/* Question Text */}
+      <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
+        {currentQuestion.questionText}
+      </h1>
+
+      {currentQuestion?.imageUrl && (
+        <div className="relative mb-[85px] min-h-[459px] w-[727px] overflow-hidden rounded-[10px]">
+          <Image
+            src={currentQuestion.imageUrl}
+            alt="문제 이미지"
+            className="size-full rounded-[10px] object-contain transition-opacity duration-300"
+            fill
+            placeholder="blur"
+            blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
+            loading="eager"
+            sizes="(max-width: 1920px) 727px, 1454px"
+          />
+        </div>
+      )}
+
+      {/* Answer Section */}
+      {showAnswer ? (
+        <SecondaryOutlineBoxButton
+          size="lg"
+          onClick={() => setShowAnswer(false)}
+        >
+          {currentQuestion?.questionAnswer}
+        </SecondaryOutlineBoxButton>
+      ) : (
+        <PrimaryBoxButton
+          size="2xl"
+          _style="solid"
+          onClick={() => setShowAnswer(true)}
+        >
+          정답 보기
+        </PrimaryBoxButton>
+      )}
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayGuard.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayGuard.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useEffect } from "react"
+import { useShallow } from "zustand/react/shallow"
+
+import { useGameStore } from "../../store/useGameStore"
+
+interface GamePlayGuardProps {
+  children: React.ReactNode
+}
+
+//gameStatus가 playing이 아니면 setup으로 리다이렉트
+//query params 검증
+export default function GamePlayGuard({ children }: GamePlayGuardProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { gameStatus, totalRounds } = useGameStore(
+    useShallow((state) => ({
+      gameStatus: state.gameStatus,
+      totalRounds: state.gameDetail?.questionCount,
+    })),
+  )
+
+  // URL 파라미터 검증
+  const q = Number(searchParams.get("q") || "1")
+  if (q < 1 || q > totalRounds) {
+    throw new Error("유효한 문제 번호가 아닙니다.")
+  }
+
+  // 게임 상태 기반 리디렉션
+  useEffect(() => {
+    if (gameStatus !== "playing") {
+      router.replace(`./setup`)
+    }
+  }, [gameStatus, router])
+
+  return <>{children}</>
+}

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
@@ -1,0 +1,77 @@
+import {
+  PrimaryBoxButton,
+  SecondaryGhostIconButton,
+  SecondaryPlainIconButton,
+} from "@ject-5-fe/design/components/button"
+import { Progress } from "@ject-5-fe/design/components/progress"
+import { Cross, Sun } from "@ject-5-fe/design/icons"
+import Image from "next/image"
+
+interface GamePlayHeaderProps {
+  currentRound: number
+  totalRounds: number
+  onPrevQuestion: () => void
+  onNextQuestion: () => void
+  onExit: () => void
+}
+
+export const GamePlayHeader = ({
+  currentRound,
+  totalRounds,
+  onPrevQuestion,
+  onNextQuestion,
+  onExit,
+}: GamePlayHeaderProps) => {
+  return (
+    <div className="mx-auto flex h-[110px] w-full shrink-0 items-center justify-between">
+      <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
+        <button
+          onClick={onExit}
+          className="flex h-[60px] w-[268px] flex-col items-center justify-center gap-2.5 p-3.5"
+        >
+          <Image
+            src="/logo.svg"
+            alt="홈 로고"
+            className="size-full"
+            width={268}
+            height={60}
+          />
+        </button>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center">
+        <Progress
+          className="h-[25px] w-[1080px]"
+          value={totalRounds > 0 ? (currentRound / totalRounds) * 100 : 0}
+          max={100}
+        />
+      </div>
+
+      <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+        <div className="flex items-center justify-end gap-4 px-10">
+          <SecondaryGhostIconButton>
+            <Sun />
+          </SecondaryGhostIconButton>
+
+          {currentRound > 1 && (
+            <PrimaryBoxButton size="sm" _style="solid" onClick={onPrevQuestion}>
+              이전 문제
+            </PrimaryBoxButton>
+          )}
+
+          <PrimaryBoxButton size="sm" _style="solid" onClick={onNextQuestion}>
+            다음 문제
+          </PrimaryBoxButton>
+
+          <SecondaryPlainIconButton
+            size="lg"
+            onClick={onExit}
+            aria-label="게임 종료"
+          >
+            <Cross />
+          </SecondaryPlainIconButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/play/components/hydrationWrapper.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/hydrationWrapper.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useGameStoreContext } from "../../store/gameProvider"
+
+interface HydrationWrapperProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
+export default function HydrationWrapper({
+  children,
+  fallback = null,
+}: HydrationWrapperProps) {
+  const gameStoreApi = useGameStoreContext()
+
+  // 하이드레이션이 완료되지 않았으면 fallback 렌더링
+  if (!gameStoreApi.persist.hasHydrated()) {
+    return <>{fallback}</>
+  }
+
+  return <>{children}</>
+}

--- a/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
@@ -1,0 +1,57 @@
+import { PrimarySolidIconButton } from "@ject-5-fe/design/components/button"
+import { PlayerStatus } from "@ject-5-fe/design/components/playerStatus"
+import { Hidden, Show } from "@ject-5-fe/design/icons"
+import { useState } from "react"
+
+import type { Team } from "../../store/useGameStore"
+
+interface ScoreboardSidebarProps {
+  teams: Team[]
+  onUpdateTeamScore: (teamId: string, score: number) => void
+}
+
+export const ScoreboardSidebar = ({
+  teams,
+  onUpdateTeamScore,
+}: ScoreboardSidebarProps) => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
+
+  const clampScore = (value: number) => Math.max(-100, Math.min(100, value))
+
+  return (
+    <div className="flex max-h-[940px] w-[400px] min-w-[400px] flex-col rounded-[20px] bg-background-tertiary">
+      <div className="relative flex items-center justify-center py-6">
+        <span className="typography-heading-sm-bold text-text-primary">
+          점수판
+        </span>
+        <PrimarySolidIconButton
+          className="absolute right-9 top-4"
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          aria-label="점수판 토글"
+        >
+          {isSidebarOpen ? <Show /> : <Hidden />}
+        </PrimarySolidIconButton>
+      </div>
+      {isSidebarOpen && (
+        <div className="flex max-h-[850px] flex-1 flex-col items-center gap-6 overflow-y-scroll px-[25px] py-6">
+          {teams.map((team) => (
+            <PlayerStatus
+              key={team.id}
+              name={team.name}
+              score={`${team.score}점`}
+              onScoreIncrease={() => {
+                const newScore = clampScore(team.score + 1)
+                onUpdateTeamScore(team.id, newScore)
+              }}
+              onScoreDecrease={() => {
+                const newScore = clampScore(team.score - 1)
+                onUpdateTeamScore(team.id, newScore)
+              }}
+              className="min-h-[118px]"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/play/layout.tsx
+++ b/service/app/src/app/game/[gameId]/play/layout.tsx
@@ -1,34 +1,14 @@
-"use client"
-
-import { useParams, useRouter } from "next/navigation"
-import { useEffect } from "react"
-
-import { useGameStoreContext } from "../store/gameProvider"
-import { useGameStore } from "../store/useGameStore"
+import GamePlayGuard from "./components/gamePlayGuard"
+import HydrationWrapper from "./components/hydrationWrapper"
 
 interface PlayLayoutProps {
   children: React.ReactNode
 }
 
 export default function PlayLayout({ children }: PlayLayoutProps) {
-  const router = useRouter()
-  const params = useParams()
-  const gameStatus = useGameStore((state) => state.gameStatus)
-  const gameStoreApi = useGameStoreContext()
-
-  useEffect(() => {
-    // persist가 안 되었으면 redirect 판단하지 않음
-    if (!gameStoreApi.persist.hasHydrated()) return
-
-    if (gameStatus !== "playing") {
-      router.replace(`/game/${params.gameId}/setup`)
-    }
-  }, [gameStatus, params.gameId, router, gameStoreApi.persist])
-
-  // 렌더는 persist 여부와 gameStatus에 따라 결정
-  if (!gameStoreApi.persist.hasHydrated() || gameStatus !== "playing") {
-    return null
-  }
-
-  return <>{children}</>
+  return (
+    <HydrationWrapper>
+      <GamePlayGuard>{children}</GamePlayGuard>
+    </HydrationWrapper>
+  )
 }

--- a/service/app/src/app/game/[gameId]/play/page.tsx
+++ b/service/app/src/app/game/[gameId]/play/page.tsx
@@ -1,230 +1,68 @@
 "use client"
-import {
-  PrimaryBoxButton,
-  PrimarySolidIconButton,
-  SecondaryGhostIconButton,
-  SecondaryOutlineBoxButton,
-  SecondaryPlainIconButton,
-} from "@ject-5-fe/design/components/button"
-import { PlayerStatus } from "@ject-5-fe/design/components/playerStatus"
-import { Progress } from "@ject-5-fe/design/components/progress"
-import { Cross, Hidden, Show, Sun } from "@ject-5-fe/design/icons"
-import Image from "next/image"
-import { useParams, useRouter } from "next/navigation"
-import { useMemo, useState } from "react"
+
+import { useRouter } from "next/navigation"
+import { useShallow } from "zustand/react/shallow"
+
+import { useTypedSearchParams } from "@/shared/lib/useTypedSearchParams"
 
 import { openExitConfirmDialog } from "../components/dialogs/exitConfirmDialog"
-import { useGameStoreContext } from "../store/gameProvider"
 import { useGameStore } from "../store/useGameStore"
+import { GamePlayContent } from "./components/gamePlayContent"
+import { GamePlayHeader } from "./components/gamePlayNavigation"
+import { ScoreboardSidebar } from "./components/scoreboardSidebar"
+import { gamePlaySchema } from "./schemas"
 
 const ScoreboardGame = () => {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
-  const [showAnswer, setShowAnswer] = useState(false)
   const router = useRouter()
-  const params = useParams()
-  const gameStoreApi = useGameStoreContext()
+  const [{ q: currentRound }, setSearchParams] =
+    useTypedSearchParams(gamePlaySchema)
 
-  const {
-    teams,
-    gameDetail,
-    currentRound,
-    totalRounds,
-    setRound,
-    updateTeamScore,
-  } = useGameStore((state) => state)
+  const { gameDetail, teams, totalRounds, updateTeamScore } = useGameStore(
+    useShallow((state) => ({
+      gameDetail: state.gameDetail,
+      teams: state.teams,
+      totalRounds: state.totalRounds,
+      updateTeamScore: state.updateTeamScore,
+    })),
+  )
 
-  const currentQuestion = gameDetail?.questions.find(
+  const currentQuestion = gameDetail.questions.find(
     (q) => q.questionOrder === currentRound - 1,
   )
 
-  const handlePrevQuestion = () => {
-    if (currentRound <= 1) return
-    const newRound = currentRound - 1
-    setRound(newRound)
-    router.replace(`?q=${newRound}`)
-    setShowAnswer(false)
+  if (!currentQuestion) {
+    throw new Error("질문을 찾을 수 없습니다.")
   }
 
   const handleNextQuestion = () => {
     if (currentRound === totalRounds) {
-      router.push(`/game/${params.gameId}/result`)
+      router.push("./result")
       return
     }
-    const newRound = Math.min(currentRound + 1, totalRounds)
-    setRound(newRound)
-    router.replace(`?q=${newRound}`)
-    setShowAnswer(false)
-  }
-
-  const handleShowAnswer = () => {
-    setShowAnswer((prev) => !prev)
-  }
-
-  const progressValue = useMemo(() => {
-    if (!totalRounds || totalRounds <= 0) return 0
-    return Math.min(
-      100,
-      Math.max(0, Math.round((currentRound / totalRounds) * 100)),
-    )
-  }, [currentRound, totalRounds])
-
-  const clampScore = (value: number) => Math.max(-100, Math.min(100, value))
-
-  const handleIncreaseScore = (teamId: string) => {
-    const team = teams.find((t) => t.id === teamId)
-    if (!team) return
-    updateTeamScore(teamId, clampScore(team.score + 1))
-  }
-
-  const handleDecreaseScore = (teamId: string) => {
-    const team = teams.find((t) => t.id === teamId)
-    if (!team) return
-    updateTeamScore(teamId, clampScore(team.score - 1))
+    setSearchParams({ q: (currentRound + 1).toString() })
   }
 
   return (
     <>
-      <div className="mx-auto flex h-[110px] w-[1920px] shrink-0 items-center justify-between">
-        <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
-          <button
-            onClick={() =>
-              openExitConfirmDialog({
-                onConfirm: () => {
-                  gameStoreApi.persist?.clearStorage?.()
-                  router.push("/")
-                },
-              })
-            }
-            className="flex h-[60px] w-[268px] flex-col items-center justify-center gap-2.5 p-3.5"
-          >
-            <Image
-              src="/logo.svg"
-              alt="홈 로고"
-              className="size-full"
-              width={268}
-              height={60}
-            />
-          </button>
-        </div>
-
-        <div className="flex flex-1 items-center justify-center">
-          <Progress
-            value={progressValue}
-            className="h-[25px] w-[1080px]"
-            max={100}
-          />
-        </div>
-
-        <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
-          <div className="flex items-center justify-end gap-4 px-10">
-            <SecondaryGhostIconButton>
-              <Sun />
-            </SecondaryGhostIconButton>
-
-            {currentRound > 1 && (
-              <PrimaryBoxButton
-                size="sm"
-                _style="solid"
-                onClick={handlePrevQuestion}
-              >
-                이전 문제
-              </PrimaryBoxButton>
-            )}
-
-            <PrimaryBoxButton
-              size="sm"
-              _style="solid"
-              onClick={handleNextQuestion}
-            >
-              다음 문제
-            </PrimaryBoxButton>
-
-            <SecondaryPlainIconButton
-              size="lg"
-              onClick={() =>
-                openExitConfirmDialog({
-                  onConfirm: () => {
-                    gameStoreApi.persist?.clearStorage?.()
-                    router.push("/")
-                  },
-                })
-              }
-              aria-label="게임 종료"
-            >
-              <Cross />
-            </SecondaryPlainIconButton>
-          </div>
-        </div>
-      </div>
-
-      {/* < className="flex">
-        {/* 사이드바 */}
-      <div className="absolute left-[20px] top-[110px] flex max-h-[940px] w-[400px] min-w-[400px] flex-col rounded-[20px] bg-background-tertiary">
-        <div className="relative flex items-center justify-center py-6">
-          <span className="typography-heading-sm-bold text-text-primary">
-            점수판
-          </span>
-          <PrimarySolidIconButton
-            className="absolute right-9 top-4"
-            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-            aria-label="점수판 토글"
-          >
-            {isSidebarOpen ? <Show /> : <Hidden />}
-          </PrimarySolidIconButton>
-        </div>
-        {isSidebarOpen && (
-          <div className="flex max-h-[850px] flex-1 flex-col items-center gap-6 overflow-y-scroll px-[25px] py-6">
-            {teams.map((team) => (
-              <PlayerStatus
-                key={team.id}
-                name={team.name}
-                score={`${team.score}점`}
-                onScoreIncrease={() => handleIncreaseScore(team.id)}
-                onScoreDecrease={() => handleDecreaseScore(team.id)}
-                className="min-h-[118px]"
-              />
-            ))}
-          </div>
-        )}
+      <GamePlayHeader
+        currentRound={currentRound}
+        totalRounds={totalRounds}
+        onPrevQuestion={() => {
+          if (currentRound <= 1) return
+          setSearchParams({ q: (currentRound - 1).toString() })
+        }}
+        onNextQuestion={handleNextQuestion}
+        onExit={() =>
+          openExitConfirmDialog({
+            onConfirm: () => router.push("/"),
+          })
+        }
+      />
+      <div className="absolute left-[20px] top-[110px]">
+        <ScoreboardSidebar teams={teams} onUpdateTeamScore={updateTeamScore} />
       </div>
       <div>
-        {/* 메인 컨텐츠 영역 */}
-        <div className="flex w-full flex-1 flex-col items-center justify-center">
-          {/* Question Text */}
-          <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
-            {currentQuestion?.questionText || "질문을 불러오는 중..."}
-          </h1>
-
-          {currentQuestion?.imageUrl && (
-            <div className="relative mb-[85px] min-h-[459px] w-[727px] overflow-hidden rounded-[10px]">
-              <Image
-                src={currentQuestion.imageUrl}
-                alt="문제 이미지"
-                className="size-full rounded-[10px] object-contain transition-opacity duration-300"
-                fill
-                placeholder="blur"
-                blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
-                loading="eager"
-                sizes="(max-width: 1920px) 727px, 1454px"
-              />
-            </div>
-          )}
-
-          {/* Answer Section */}
-          {showAnswer ? (
-            <SecondaryOutlineBoxButton size="lg" onClick={handleShowAnswer}>
-              {currentQuestion?.questionAnswer}
-            </SecondaryOutlineBoxButton>
-          ) : (
-            <PrimaryBoxButton
-              size="2xl"
-              _style="solid"
-              onClick={handleShowAnswer}
-            >
-              정답 보기
-            </PrimaryBoxButton>
-          )}
-        </div>
+        <GamePlayContent currentQuestion={currentQuestion} />
       </div>
     </>
   )

--- a/service/app/src/app/game/[gameId]/play/schemas/index.ts
+++ b/service/app/src/app/game/[gameId]/play/schemas/index.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+export const gamePlaySchema = z.object({
+  q: z.string().default("1").transform(Number),
+})

--- a/service/app/src/app/game/[gameId]/result/components/gameResultContent.tsx
+++ b/service/app/src/app/game/[gameId]/result/components/gameResultContent.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from "react"
+
+import type { Team } from "../../store/useGameStore"
+
+interface GameResultContentProps {
+  teams: Team[]
+}
+
+export const GameResultContent = ({ teams }: GameResultContentProps) => {
+  // 점수 내림차순으로 정렬하여 상위 3팀 추출
+  const topTeams = useMemo(() => {
+    return [...teams].sort((a, b) => b.score - a.score).slice(0, 3)
+  }, [teams])
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-10">
+      {/* Winner Title */}
+      <div className="flex h-24 items-center justify-center gap-2.5 rounded-[15px] bg-blue-400 px-8 py-2.5">
+        <h2 className="typography-heading-3xl-semibold text-neutral-white">
+          🎉 이번 게임의 Winner는?
+        </h2>
+      </div>
+
+      {/* Scoreboard */}
+      <div className="flex flex-col gap-6">
+        {topTeams.map((team) => (
+          <div
+            key={team.id}
+            className="flex items-center justify-center gap-[30px] rounded-[10px] bg-gray-100 px-[110px] py-[18px]"
+          >
+            <span className="text-[57px] font-bold text-blue-700">
+              {team.name}
+            </span>
+            <span className="text-[57px] font-bold text-blue-400">
+              {team.score}점
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/result/components/gameResultNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/result/components/gameResultNavigation.tsx
@@ -1,0 +1,64 @@
+import {
+  PrimaryBoxButton,
+  SecondaryGhostIconButton,
+  SecondaryPlainIconButton,
+} from "@ject-5-fe/design/components/button"
+import { Cross, Sun } from "@ject-5-fe/design/icons"
+import Image from "next/image"
+
+interface GameResultNavigationProps {
+  onGoHome: () => void
+  onPreviousQuestion: () => void
+}
+
+export const GameResultNavigation = ({
+  onGoHome,
+  onPreviousQuestion,
+}: GameResultNavigationProps) => {
+  return (
+    <div className="mx-auto flex h-[110px] w-full shrink-0 items-center justify-between">
+      <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
+        <button
+          onClick={onGoHome}
+          className="flex h-[60px] w-[268px] flex-col items-center justify-center gap-2.5 p-3.5"
+        >
+          <Image
+            src="/logo.svg"
+            alt="홈 로고"
+            className="size-full"
+            width={268}
+            height={60}
+          />
+        </button>
+      </div>
+
+      <h1 className="typography-heading-lg-semibold whitespace-nowrap text-center text-text-primary">
+        게임 종료
+      </h1>
+
+      <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+        <div className="flex items-center justify-end gap-4 px-10">
+          <SecondaryGhostIconButton>
+            <Sun />
+          </SecondaryGhostIconButton>
+
+          <PrimaryBoxButton
+            size="sm"
+            _style="solid"
+            onClick={onPreviousQuestion}
+          >
+            이전 문제
+          </PrimaryBoxButton>
+
+          <SecondaryPlainIconButton
+            size="lg"
+            onClick={onGoHome}
+            aria-label="게임 종료"
+          >
+            <Cross />
+          </SecondaryPlainIconButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/service/app/src/app/game/[gameId]/result/page.tsx
+++ b/service/app/src/app/game/[gameId]/result/page.tsx
@@ -1,111 +1,26 @@
 "use client"
 
-import { PrimaryBoxButton } from "@ject-5-fe/design/components/button"
-import { Cross, Sun } from "@ject-5-fe/design/icons"
-import Image from "next/image"
-import { useParams, useRouter } from "next/navigation"
-import { useMemo } from "react"
+import { useRouter } from "next/navigation"
 
 import { useGameStore } from "../store/useGameStore"
+import { GameResultContent } from "./components/gameResultContent"
+import { GameResultNavigation } from "./components/gameResultNavigation"
 
 export default function GameResultPage() {
   const router = useRouter()
-  const params = useParams()
   const { teams, totalRounds } = useGameStore((state) => state)
-
-  // 점수 내림차순으로 정렬하여 상위 3팀 추출
-  const topTeams = useMemo(() => {
-    return [...teams]
-      .sort((a, b) => b.score - a.score)
-      .slice(0, 3)
-      .map((team) => ({
-        name: team.name,
-        score: team.score,
-      }))
-  }, [teams])
 
   const handleGoHome = () => {
     router.push("/")
   }
 
-  const handlePreviousQuestion = () => {
-    // 이전 문제로 이동 (마지막 문제에서 이전 문제로)
-    const previousRound = Math.max(1, totalRounds - 1)
-    router.push(`/game/${params.gameId}/play?q=${previousRound}`)
-  }
-
   return (
-    <div className="flex min-h-screen flex-col items-center bg-background-primary">
-      {/* Navigation */}
-      <div className="mx-auto flex h-[110px] w-[1920px] shrink-0 items-center justify-between">
-        <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
-          <button
-            onClick={handleGoHome}
-            className="flex h-[60px] w-[268px] flex-col items-center justify-center gap-2.5 p-3.5"
-          >
-            <Image
-              src="/logo.svg"
-              alt="홈 로고"
-              className="size-full"
-              width={268}
-              height={60}
-            />
-          </button>
-        </div>
-
-        <h1 className="typography-heading-lg-semibold whitespace-nowrap text-center text-text-primary">
-          게임 종료
-        </h1>
-
-        <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
-          <div className="flex items-center justify-end gap-4 px-10">
-            <button className="flex items-center justify-center gap-2.5 rounded-lg p-2.5">
-              <Sun size={24} className="text-icon-interactive-secondary" />
-            </button>
-            <PrimaryBoxButton
-              size="sm"
-              _style="solid"
-              onClick={handlePreviousQuestion}
-            >
-              이전 문제
-            </PrimaryBoxButton>
-            <button className="flex size-8 items-center justify-center">
-              <Cross
-                size={32}
-                className="text-icon-interactive-secondary"
-                onClick={handleGoHome}
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="flex flex-1 flex-col items-center justify-center gap-10">
-        {/* Winner Title */}
-        <div className="flex h-24 items-center justify-center gap-2.5 rounded-[15px] bg-blue-400 px-8 py-2.5">
-          <h2 className="typography-heading-3xl-semibold text-neutral-white">
-            🎉 이번 게임의 Winner는?
-          </h2>
-        </div>
-
-        {/* Scoreboard */}
-        <div className="flex flex-col gap-6">
-          {topTeams.map((team) => (
-            <div
-              key={team.name}
-              className="flex items-center justify-center gap-[30px] rounded-[10px] bg-gray-100 px-[110px] py-[18px]"
-            >
-              <span className="text-[57px] font-bold text-blue-700">
-                {team.name}
-              </span>
-              <span className="text-[57px] font-bold text-blue-400">
-                {team.score}점
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
+    <>
+      <GameResultNavigation
+        onGoHome={handleGoHome}
+        onPreviousQuestion={() => router.push(`./play?q=${totalRounds - 1}`)}
+      />
+      <GameResultContent teams={teams} />
+    </>
   )
 }

--- a/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
@@ -6,8 +6,6 @@ import { ThemeToggle } from "@ject-5-fe/design/components/themeToggle"
 import { Cross } from "@ject-5-fe/design/icons"
 import Image from "next/image"
 import Link from "next/link"
-import { useTheme } from "next-themes"
-import { useEffect, useState } from "react"
 
 interface GameNavigationProps {
   onStart: () => void
@@ -20,17 +18,6 @@ export function GameNavigation({
   onExit,
   isStartEnabled,
 }: GameNavigationProps) {
-  const { setTheme, resolvedTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  const handleThemeToggle = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark")
-  }
-
   return (
     <div className="mx-auto flex h-[110px] w-[1920px] shrink-0 items-center justify-between">
       <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
@@ -54,12 +41,8 @@ export function GameNavigation({
 
       <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
         <div className="flex items-center justify-end gap-4 px-10">
-          {mounted && (
-            <ThemeToggle
-              theme={(resolvedTheme as "dark" | "light") || "light"}
-              onThemeToggle={handleThemeToggle}
-            />
-          )}
+          <ThemeToggle />
+
           <PrimaryBoxButton
             size="sm"
             _style="solid"

--- a/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
@@ -1,3 +1,4 @@
+"use client"
 import {
   PrimaryBoxButton,
   SecondaryPlainIconButton,
@@ -6,20 +7,22 @@ import { ThemeToggle } from "@ject-5-fe/design/components/themeToggle"
 import { Cross } from "@ject-5-fe/design/icons"
 import Image from "next/image"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 
-interface GameNavigationProps {
-  onStart: () => void
-  onExit: () => void
-  isStartEnabled: boolean
-}
+import { openExitConfirmDialog } from "../../components/dialogs/exitConfirmDialog"
+import { useGameStore } from "../../store/useGameStore"
+import { canStartGame } from "../../utils/teamValidation"
 
-export function GameNavigation({
-  onStart,
-  onExit,
-  isStartEnabled,
-}: GameNavigationProps) {
+export function GameNavigation() {
+  const setGameStatus = useGameStore((state) => state.setGameStatus)
+  const teams = useGameStore((state) => state.teams)
+
+  const isGameReady = canStartGame(teams)
+
+  const router = useRouter()
+
   return (
-    <div className="mx-auto flex h-[110px] w-[1920px] shrink-0 items-center justify-between">
+    <div className="mx-auto flex h-[110px] w-full shrink-0 items-center justify-between">
       <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
         <Link
           href="/"
@@ -46,12 +49,24 @@ export function GameNavigation({
           <PrimaryBoxButton
             size="sm"
             _style="solid"
-            disabled={!isStartEnabled}
-            onClick={onStart}
+            disabled={!isGameReady}
+            onClick={() => {
+              if (isGameReady) {
+                setGameStatus("playing")
+                router.push("./play")
+              }
+            }}
           >
             게임 시작
           </PrimaryBoxButton>
-          <SecondaryPlainIconButton size="lg" onClick={onExit}>
+          <SecondaryPlainIconButton
+            size="lg"
+            onClick={() => {
+              openExitConfirmDialog({
+                onConfirm: () => router.push("/"),
+              })
+            }}
+          >
             <Cross />
           </SecondaryPlainIconButton>
         </div>

--- a/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { PrimaryBoxButton } from "@ject-5-fe/design/components/button"
+import * as InputComponents from "@ject-5-fe/design/components/input"
+import { useMemo } from "react"
+import { v4 as uuidv4 } from "uuid"
+import { useShallow } from "zustand/react/shallow"
+
+import { useGameStore } from "../../store/useGameStore"
+import { generateTeamName } from "../../utils/generateTeamName"
+import {
+  getTeamErrors,
+  MAX_TEAM_NAME_LENGTH,
+  MAX_TEAMS,
+  MIN_TEAMS,
+} from "../../utils/teamValidation"
+
+export function TeamInputForm() {
+  const { teams, addTeam, removeTeam, updateTeamName } = useGameStore(
+    useShallow((state) => ({
+      teams: state.teams,
+      addTeam: state.addTeam,
+      removeTeam: state.removeTeam,
+      updateTeamName: state.updateTeamName,
+    })),
+  )
+
+  const teamErrors = useMemo(() => getTeamErrors(teams), [teams])
+
+  return (
+    <InputComponents.Root
+      className="flex w-full flex-col gap-6"
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (teams.length >= MAX_TEAMS) {
+          return
+        }
+
+        addTeam({
+          id: uuidv4(),
+          name: generateTeamName(teams.length),
+          score: 0,
+          members: [],
+        })
+      }}
+    >
+      {teams.map((team, index) => (
+        <InputComponents.Field
+          name={`team-${team.id}-${index}`}
+          type="reset"
+          state={teamErrors[team.id] ? "error" : "default"}
+          key={team.id}
+        >
+          <InputComponents.Control
+            value={team.name}
+            onChange={(value) => {
+              if (value.length > MAX_TEAM_NAME_LENGTH) {
+                return
+              }
+              updateTeamName(team.id, value)
+            }}
+            onReset={() => {
+              if (teams.length > MIN_TEAMS) {
+                removeTeam(team.id)
+              }
+            }}
+            maxLength={MAX_TEAM_NAME_LENGTH}
+            max={MAX_TEAM_NAME_LENGTH}
+          />
+          {teamErrors[team.id] && (
+            <InputComponents.ErrorText>
+              {teamErrors[team.id]}
+            </InputComponents.ErrorText>
+          )}
+        </InputComponents.Field>
+      ))}
+      <PrimaryBoxButton
+        size="xl"
+        _style="solid"
+        disabled={teams.length >= MAX_TEAMS}
+      >
+        참가자 및 팀 추가하기
+      </PrimaryBoxButton>
+    </InputComponents.Root>
+  )
+}

--- a/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
@@ -57,7 +57,7 @@ export function TeamInputForm() {
               if (value.length > MAX_TEAM_NAME_LENGTH) {
                 return
               }
-              updateTeamName(team.id, value)
+              updateTeamName(team.id, value.trim())
             }}
             onReset={() => {
               if (teams.length > MIN_TEAMS) {

--- a/service/app/src/app/game/[gameId]/setup/components/teamSidebar.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/teamSidebar.tsx
@@ -1,12 +1,11 @@
+"use client"
+
 import { PlayerStatus } from "@ject-5-fe/design/components/playerStatus"
 
-import type { Team } from "../../store/useGameStore"
+import { useGameStore } from "../../store/useGameStore"
 
-interface TeamSidebarProps {
-  teams: Team[]
-}
-
-export function TeamSidebar({ teams }: TeamSidebarProps) {
+export function TeamSidebar() {
+  const teams = useGameStore((state) => state.teams)
   return (
     <aside className="flex h-full w-[420px] flex-col items-center gap-6 overflow-y-auto bg-background-tertiary px-[35px] pt-[25px]">
       {teams.map((team) => (

--- a/service/app/src/app/game/[gameId]/setup/page.tsx
+++ b/service/app/src/app/game/[gameId]/setup/page.tsx
@@ -1,161 +1,19 @@
-"use client"
-
-import { PrimaryBoxButton } from "@ject-5-fe/design/components/button"
-import * as InputComponents from "@ject-5-fe/design/components/input"
-import { useParams, useRouter } from "next/navigation"
-import { useMemo } from "react"
-import { v4 as uuidv4 } from "uuid"
-import { useShallow } from "zustand/react/shallow"
-
-import { openExitConfirmDialog } from "../components/dialogs/exitConfirmDialog"
-import { type Team, useGameStore } from "../store/useGameStore"
 import { GameNavigation } from "./components/gameNavigation"
+import { TeamInputForm } from "./components/teamInputForm"
 import { TeamSidebar } from "./components/teamSidebar"
 
-const MIN_TEAMS = 2
-const MAX_TEAMS = 10
-const MAX_TEAM_NAME_LENGTH = 30
-
-const validateTeamName = (
-  teamId: string,
-  name: string,
-  teams: Team[],
-): string => {
-  if (name.length === 0) {
-    return "팀명을 비워둘 수 없어요."
-  }
-  if (name.length > MAX_TEAM_NAME_LENGTH) {
-    return "팀명은 30자까지만 가능해요."
-  }
-  if (teams.some((team) => team.id !== teamId && team.name === name)) {
-    return "이미 사용중인 팀명이에요."
-  }
-  return ""
-}
-
 export default function GameSetupPage() {
-  const params = useParams()
-  const router = useRouter()
-
-  const { teams, addTeam, removeTeam, updateTeamName, setGameStatus } =
-    useGameStore(
-      useShallow((state) => ({
-        teams: state.teams,
-        addTeam: state.addTeam,
-        removeTeam: state.removeTeam,
-        updateTeamName: state.updateTeamName,
-        setGameStatus: state.setGameStatus,
-      })),
-    )
-
-  //팀에 대한 유효성 검사 - 전역 store에 추가하지 않고 관리
-  const teamErrors = useMemo(
-    () =>
-      teams.reduce(
-        (errors, team) => {
-          const error = validateTeamName(team.id, team.name, teams)
-          if (error) {
-            errors[team.id] = error
-          }
-          return errors
-        },
-        {} as { [teamId: string]: string },
-      ),
-    [teams],
-  )
-
-  const handleUpdateTeamName = (teamId: string, name: string) => {
-    if (name.length > MAX_TEAM_NAME_LENGTH) {
-      return
-    }
-    updateTeamName(teamId, name)
-  }
-
-  const handleAddTeam = () => {
-    if (teams.length >= MAX_TEAMS) {
-      return
-    }
-
-    const newId = uuidv4()
-    const newTeamName = `${String.fromCharCode(65 + teams.length)}팀`
-    addTeam({
-      id: newId,
-      name: newTeamName,
-      score: 0,
-      members: [],
-    })
-  }
-
-  const handleRemoveTeam = (teamId: string) => {
-    removeTeam(teamId)
-  }
-
-  const handleExitClick = () => {
-    openExitConfirmDialog({
-      onConfirm: () => router.push("/"),
-    })
-  }
-
   return (
-    <div className="flex h-screen w-screen flex-col bg-background-primary">
-      <GameNavigation
-        onStart={() => {
-          setGameStatus("playing")
-          router.push(`/game/${params.gameId}/play`)
-        }}
-        onExit={handleExitClick}
-        isStartEnabled={Object.keys(teamErrors).length === 0}
-      />
+    <>
+      <GameNavigation />
       <section className="flex flex-1 overflow-hidden">
-        <TeamSidebar teams={teams} />
+        <TeamSidebar />
         <div className="flex h-full flex-1 flex-col items-center justify-center">
           <div className="flex max-h-full min-w-[452px] flex-col items-center justify-start overflow-y-auto">
-            <InputComponents.Root
-              className="flex w-full flex-col gap-6"
-              onSubmit={(e) => {
-                e.preventDefault()
-                handleAddTeam()
-              }}
-            >
-              {teams.map((team, index) => (
-                <div key={team.id}>
-                  <InputComponents.Field
-                    name={`team-${team.id}-${index}`}
-                    type="reset"
-                    state={teamErrors[team.id] ? "error" : "default"}
-                  >
-                    <InputComponents.Control
-                      value={team.name}
-                      onChange={(value) => handleUpdateTeamName(team.id, value)}
-                      onReset={() => {
-                        if (teams.length > MIN_TEAMS) {
-                          handleRemoveTeam(team.id)
-                        }
-                      }}
-                      maxLength={MAX_TEAM_NAME_LENGTH}
-                      max={MAX_TEAM_NAME_LENGTH}
-                    />
-                    {teamErrors[team.id] && (
-                      <InputComponents.ErrorText>
-                        {teamErrors[team.id]}
-                      </InputComponents.ErrorText>
-                    )}
-                  </InputComponents.Field>
-                </div>
-              ))}
-              <PrimaryBoxButton
-                size="xl"
-                _style="solid"
-                disabled={teams.length >= MAX_TEAMS}
-                onClick={handleAddTeam}
-                type="button"
-              >
-                참가자 및 팀 추가하기
-              </PrimaryBoxButton>
-            </InputComponents.Root>
+            <TeamInputForm />
           </div>
         </div>
       </section>
-    </div>
+    </>
   )
 }

--- a/service/app/src/app/game/[gameId]/store/gameProvider.tsx
+++ b/service/app/src/app/game/[gameId]/store/gameProvider.tsx
@@ -15,7 +15,7 @@ const [GameStoreProvider, useGameStoreContext] = buildContext<GameStoreApi>(
 
 export interface GameProviderProps {
   children: ReactNode
-  initialGameDetail?: GameDetailData
+  initialGameDetail: GameDetailData
   gameId?: string
 }
 

--- a/service/app/src/app/game/[gameId]/store/useGameStore.tsx
+++ b/service/app/src/app/game/[gameId]/store/useGameStore.tsx
@@ -20,10 +20,9 @@ export interface Team {
 }
 
 interface GameState {
-  gameDetail: GameDetailData | null
+  gameDetail: GameDetailData
   teams: Team[]
   gameStatus: "setup" | "playing" | "paused" | "finished"
-  currentRound: number
   totalRounds: number
 }
 
@@ -36,9 +35,6 @@ interface GameActions {
 
   // 게임 진행
   setGameStatus: (status: GameState["gameStatus"]) => void
-  setRound: (round: number) => void
-  nextRound: () => void
-  prevRound: () => void
 
   // 초기화
   resetGame: () => void
@@ -59,8 +55,7 @@ export const createGameStore = (
         gameDetail: initialGameDetail,
         teams: DEFAULT_TEAMS.map((team) => ({ ...team, score: 0 })),
         gameStatus: "setup",
-        currentRound: 1,
-        totalRounds: initialGameDetail.questionCount || 1,
+        totalRounds: initialGameDetail.questionCount,
 
         addTeam: (team) =>
           set((state) => {
@@ -102,30 +97,10 @@ export const createGameStore = (
         // 게임 진행 액션들
         setGameStatus: (gameStatus) => set({ gameStatus }),
 
-        setRound: (round) =>
-          set((state) => {
-            state.currentRound = Math.max(1, Math.min(round, state.totalRounds))
-          }),
-
-        nextRound: () =>
-          set((state) => {
-            if (state.currentRound < state.totalRounds) {
-              state.currentRound += 1
-            }
-          }),
-
-        prevRound: () =>
-          set((state) => {
-            if (state.currentRound > 1) {
-              state.currentRound -= 1
-            }
-          }),
-
         resetGame: () =>
           set((state) => {
             state.teams = DEFAULT_TEAMS.map((team) => ({ ...team, score: 0 }))
             state.gameStatus = "setup"
-            state.currentRound = 1
           }),
       })),
       {
@@ -134,9 +109,6 @@ export const createGameStore = (
         partialize: (state) => ({
           teams: state.teams,
           gameStatus: state.gameStatus,
-          currentRound: state.currentRound,
-          totalRounds: state.totalRounds,
-          gameDetail: state.gameDetail,
         }),
       },
     ),

--- a/service/app/src/app/game/[gameId]/store/useGameStore.tsx
+++ b/service/app/src/app/game/[gameId]/store/useGameStore.tsx
@@ -28,7 +28,6 @@ interface GameState {
 }
 
 interface GameActions {
-  // 팀 관리 - 플랫 구조
   addTeam: (team: Team) => void
   removeTeam: (teamId: string) => void
   updateTeamName: (teamId: string, name: string) => void
@@ -51,17 +50,17 @@ const findTeamIndex = (teams: Team[], teamId: string): number => {
 }
 
 export const createGameStore = (
-  initialGameDetail?: GameDetailData,
+  initialGameDetail: GameDetailData,
   gameId?: string,
 ) =>
   create<GameState & GameActions>()(
     persist(
       immer((set) => ({
-        gameDetail: initialGameDetail || null,
+        gameDetail: initialGameDetail,
         teams: DEFAULT_TEAMS.map((team) => ({ ...team, score: 0 })),
         gameStatus: "setup",
         currentRound: 1,
-        totalRounds: initialGameDetail?.questionCount || 1,
+        totalRounds: initialGameDetail.questionCount || 1,
 
         addTeam: (team) =>
           set((state) => {

--- a/service/app/src/app/game/[gameId]/utils/generateTeamName.ts
+++ b/service/app/src/app/game/[gameId]/utils/generateTeamName.ts
@@ -1,0 +1,7 @@
+// 65 = 'A' 를 기준으로 팀 이름 생성
+// 예시: 0 -> A팀, 1 -> B팀, 2 -> C팀
+// 알파벳을 넘어가는 경우는 없음
+export const generateTeamName = (index: number) => {
+  const letter = String.fromCharCode(65 + index)
+  return `${letter}팀`
+}

--- a/service/app/src/app/game/[gameId]/utils/teamValidation.ts
+++ b/service/app/src/app/game/[gameId]/utils/teamValidation.ts
@@ -1,0 +1,38 @@
+export const MIN_TEAMS = 2
+export const MAX_TEAMS = 10
+export const MAX_TEAM_NAME_LENGTH = 30
+
+import type { Team } from "../store/useGameStore"
+
+export const validateTeamName = (
+  teamId: string,
+  name: string,
+  teams: Team[],
+): string => {
+  if (name.length === 0) {
+    return "팀명을 비워둘 수 없어요."
+  }
+  if (name.length > MAX_TEAM_NAME_LENGTH) {
+    return "팀명은 30자까지만 가능해요."
+  }
+  if (teams.some((team) => team.id !== teamId && team.name === name)) {
+    return "이미 사용중인 팀명이에요."
+  }
+  return ""
+}
+//teamId별로 유효성검사의 에러 메시지를 담는 객체
+export const getTeamErrors = (teams: Team[]): { [teamId: string]: string } => {
+  return teams.reduce<{ [teamId: string]: string }>((errors, team) => {
+    const error = validateTeamName(team.id, team.name, teams)
+    if (error) {
+      errors[team.id] = error
+    }
+    return errors
+  }, {})
+}
+
+export const canStartGame = (teams: Team[]) => {
+  if (teams.length < MIN_TEAMS) return false
+  const errors = getTeamErrors(teams)
+  return Object.keys(errors).length === 0
+}

--- a/service/app/src/app/game/[gameId]/utils/teamValidation.ts
+++ b/service/app/src/app/game/[gameId]/utils/teamValidation.ts
@@ -13,7 +13,7 @@ export const validateTeamName = (
     return "팀명을 비워둘 수 없어요."
   }
   if (name.length > MAX_TEAM_NAME_LENGTH) {
-    return "팀명은 30자까지만 가능해요."
+    return `팀명은 ${MAX_TEAM_NAME_LENGTH}자까지만 가능해요.`
   }
   if (teams.some((team) => team.id !== teamId && team.name === name)) {
     return "이미 사용중인 팀명이에요."

--- a/service/app/src/shared/lib/useTypedSearchParams.ts
+++ b/service/app/src/shared/lib/useTypedSearchParams.ts
@@ -1,0 +1,69 @@
+"use client"
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useMemo } from "react"
+import { z } from "zod"
+
+type NewParamsType = { [key: string]: string }
+
+export const useTypedSearchParams = <T extends z.ZodTypeAny>(schema: T) => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const parsedParams = useMemo(() => {
+    const params: Record<string, string | string[]> = {}
+
+    searchParams.forEach((value, key) => {
+      const existing = params[key]
+      if (existing) {
+        if (Array.isArray(existing)) {
+          existing.push(value)
+        } else {
+          params[key] = [existing, value]
+        }
+      } else {
+        params[key] = value
+      }
+    })
+    const result = schema.parse(params)
+
+    return result
+  }, [schema, searchParams])
+
+  const setSearchParams = useCallback(
+    (
+      newParams: NewParamsType | ((prev: NewParamsType) => NewParamsType),
+      isReplace?: boolean,
+    ) => {
+      const _newParams =
+        typeof newParams === "function"
+          ? newParams(Object.fromEntries(searchParams))
+          : newParams
+
+      // 새로운 URLSearchParams 생성
+      const current = new URLSearchParams(searchParams.toString())
+
+      // 새로운 파라미터 적용
+      Object.entries(_newParams).forEach(([key, value]) => {
+        if (value) {
+          current.set(key, value)
+        } else {
+          current.delete(key)
+        }
+      })
+
+      const search = current.toString()
+      const query = search ? `?${search}` : ""
+
+      if (isReplace) {
+        router.replace(`${pathname}${query}`, { scroll: false })
+      } else {
+        router.push(`${pathname}${query}`, { scroll: false })
+      }
+    },
+    [searchParams, pathname, router],
+  )
+
+  return [parsedParams, setSearchParams] as const
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7750,6 +7750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -8403,6 +8412,7 @@ __metadata:
     commitizen: "npm:^4.3.1"
     cz-conventional-changelog: "npm:^3.3.0"
     eslint: "npm:^9"
+    husky: "npm:^9.1.7"
     lint-staged: "npm:^16.1.2"
     playwright: "npm:^1.53.1"
     prettier: "npm:^3.5"


### PR DESCRIPTION
## 📝 설명


## 🛠️ 주요 변경 사항
### 게임 진행페이지 리팩토링
- 모든 라우터 페이지를 필요에 맞게 client / server로 분리
- game play 로직변경
- 브라우저의 뒤로가기/앞으로가기와 게임진행을 동기화하기 위해서 url을 기반으로 동작하도록 변경
- `shared` 폴더 생성 및 `useTypedSearchParams` custom hook 생성 bebab39564e8449152d5028809d6ad3ccadd11f8

- playwright 관련 Cursor rule 수정 969e41265b18088d5beeafec51126cd68db251ab
- husky 패키지 설치 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 게임 플레이/결과 UI 구성요소 추가(네비게이션, 콘텐츠, 점수판 사이드바) 및 오류 페이지 도입
  - URL 쿼리 스키마 기반 탐색(useTypedSearchParams), 플레이 가드 및 하이드레이션 래퍼 추가
  - 팀 입력 폼 도입, 팀명 자동 생성·검증 유틸 제공
- Refactor
  - 페이지들을 컴포넌트 중심으로 재구성하고 전역 스토어 연동 단순화(라운드 이동은 쿼리 기반)
- Tests
  - 네비게이션 동기화·진행도 검증 강화로 Playwright 테스트 안정화
- Documentation
  - Playwright 가이드: 접근성 우선 로케이터·자동 재시도 어설션 중심으로 개편
- Chores
  - VSCode에서 ESLint 포맷팅 활성화 및 Husky 도입
<!-- end of auto-generated comment: release notes by coderabbit.ai -->