### PR TITLE
playwright cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: yarn run ci
 
       - name: Build Next.js app for E2E tests
-        run: yarn workspace @ject-5-fe/app build
+        run: NEXT_PUBLIC_TEST="1" yarn workspace @ject-5-fe/app build
 
       - name: Cache E2E test results
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,20 @@ jobs:
       - name: Run CI
         run: yarn run ci
 
+      - name: Build Next.js app for E2E tests
+        run: yarn workspace @ject-5-fe/app build
+
+      - name: Cache E2E test results
+        uses: actions/cache@v4
+        with:
+          path: service/app/test-cache-map.json
+          key: e2e-tests-${{ hashFiles('service/app/.next/app-build-manifest.json') }}
+          restore-keys: |
+            e2e-tests-
+
+      - name: Run E2E test with cache
+        run: yarn workspace @ject-5-fe/app run test:e2e-cached
+
       - name: build vercel preview
         uses: amondnet/vercel-action@v20
         id: vercel-preview-deploy
@@ -69,27 +83,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORGID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECTID }}
-
-      # - name: Run Playwright tests on preview
-      #   run: yarn workspace @ject-5-fe/app test:e2e
-      #   env:
-      #     PLAYWRIGHT_BASE_URL: ${{ steps.vercel-preview-deploy.outputs.preview-url }}
-
-      - name: Comment on PR - Success
-        if: success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `✅ **CI 및 E2E 테스트 성공!**
-              
-              🚀 Preview URL: ${{ steps.vercel-preview-deploy.outputs.preview-url }}
-              
-              모든 테스트가 통과했습니다. 코드 리뷰를 진행해주세요!`
-            })
 
       - name: Comment on PR - Failure
         if: failure()

--- a/service/app/next.config.mjs
+++ b/service/app/next.config.mjs
@@ -26,7 +26,7 @@ const nextConfig = {
 
     return {
       ...config,
-      devtool: isServer ? "inline-source-map" : false,
+      devtool: process.env.NODE_ENV === "test" ? "inline-source-map" : false,
     }
   },
   images: {

--- a/service/app/next.config.mjs
+++ b/service/app/next.config.mjs
@@ -19,7 +19,15 @@ const nextConfig = {
       }
     }
 
-    return config
+    config.output.filename = config.output.filename.replace(
+      "[chunkhash]",
+      "[contenthash]",
+    )
+
+    return {
+      ...config,
+      devtool: isServer ? "inline-source-map" : false,
+    }
   },
   images: {
     remotePatterns: [
@@ -33,6 +41,12 @@ const nextConfig = {
       },
     ],
   },
+
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+
+  productionBrowserSourceMaps: process.env.NODE_ENV !== "production",
 }
 
 export default nextConfig

--- a/service/app/next.config.mjs
+++ b/service/app/next.config.mjs
@@ -26,7 +26,7 @@ const nextConfig = {
 
     return {
       ...config,
-      devtool: process.env.NODE_ENV === "test" ? "inline-source-map" : false,
+      devtool: process.env.NEXT_PUBLIC_TEST ? "inline-source-map" : false,
     }
   },
   images: {
@@ -46,7 +46,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
 
-  productionBrowserSourceMaps: process.env.NODE_ENV !== "production",
+  productionBrowserSourceMaps: !!process.env.NEXT_PUBLIC_TEST,
 }
 
 export default nextConfig

--- a/service/app/package.json
+++ b/service/app/package.json
@@ -11,8 +11,9 @@
     "format": "yarn run -T -B prettier --write",
     "test": "vitest run",
     "test:msw": "vitest run --config vitest.msw.config.ts",
-    "test:all": "yarn test && yarn test:msw && yarn test:e2e",
-    "test:e2e": "playwright test --config=playwright.config.ts"
+    "test:all": "yarn test && yarn test:msw",
+    "test:e2e": "playwright test --config=playwright.config.ts",
+    "test:e2e-cached": "yarn node scripts/playwright.ts"
   },
   "dependencies": {
     "@ject-5-fe/design": "workspace:*",
@@ -43,6 +44,7 @@
     "@vitejs/plugin-react": "^4",
     "@vitest/browser": "^3.2.4",
     "autoprefixer": "^10.4.21",
+    "glob": "^11.0.3",
     "msw": "^2.10.3",
     "playwright": "^1.53.1",
     "postcss": "^8.5.5",

--- a/service/app/playwright.config.ts
+++ b/service/app/playwright.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: "yarn dev",
+        command: process.env.CI
+          ? "yarn build && NEXT_PUBLIC_TEST=true yarn start"
+          : "yarn dev",
         url: "http://localhost:3000",
         reuseExistingServer: true,
       },

--- a/service/app/playwright.config.ts
+++ b/service/app/playwright.config.ts
@@ -20,9 +20,7 @@ export default defineConfig({
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: process.env.CI
-          ? "yarn build && NEXT_PUBLIC_TEST=true yarn start"
-          : "yarn dev",
+        command: process.env.CI ? "NEXT_PUBLIC_TEST=1 yarn start" : "yarn dev",
         url: "http://localhost:3000",
         reuseExistingServer: true,
       },

--- a/service/app/scripts/playwright.ts
+++ b/service/app/scripts/playwright.ts
@@ -66,12 +66,21 @@ async function runTests(testFiles: string[]) {
 
   try {
     return new Promise<void>((resolve, reject) => {
+      // 브래킷이 포함된 파일 경로를 따옴표로 감싸서 shell glob 해석 방지
+      const escapedTestFiles = testFiles.map((file) => `"${file}"`)
+
       const testProcess = spawn(
         "yarn",
-        ["playwright", "test", "--config=playwright.config.ts", ...testFiles],
+        [
+          "playwright",
+          "test",
+          "--config=playwright.config.ts",
+          ...escapedTestFiles,
+        ],
         {
           stdio: "inherit",
           cwd: import.meta.dirname + "/..",
+          shell: true,
         },
       )
 
@@ -216,4 +225,7 @@ async function main() {
   console.log(`\n💾 Cache updated: ${cacheFile}`)
 }
 
-main().catch(console.error)
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/service/app/scripts/playwright.ts
+++ b/service/app/scripts/playwright.ts
@@ -7,7 +7,41 @@ const { spawn } = await import("child_process")
 const buildDir = path.join(import.meta.dirname, "../.next")
 const cacheFile = path.join(import.meta.dirname, "../test-cache-map.json")
 
-async function findRoutes(pattern: string = "**/*.spec.ts") {
+function calculateHash(content: string) {
+  return crypto.createHash("sha256").update(content).digest("hex")
+}
+
+// sourceMap에서 sourcesContent만 추출하는 함수
+function parseSourceMap(content: string) {
+  try {
+    // sourceMappingURL= 라인을 찾기
+    const sourceMapMatch = content.match(
+      /\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,([^\s]+)/,
+    )
+    if (!sourceMapMatch || !sourceMapMatch[1]) {
+      return content
+    }
+
+    // base64 부분 추출 및 디코딩
+    const base64Data = sourceMapMatch[1]
+    const decodedData = Buffer.from(base64Data, "base64").toString("utf-8")
+    // JSON 파싱해서 sourcesContent만 추출
+    const sourceMap = JSON.parse(decodedData)
+
+    if (sourceMap.sourcesContent && Array.isArray(sourceMap.sourcesContent)) {
+      // sourcesContent 배열의 모든 내용을 합쳐서 반환
+      return sourceMap.sourcesContent.join("")
+    }
+    console.log("없음")
+    return content
+  } catch (error) {
+    console.error("Error parsing source map:", error)
+    return content
+  }
+}
+
+//e2e 테스트파일의 실제 테스트 라우트 찾기
+async function findTestRoutes(pattern: string = "**/*.spec.ts") {
   const testFiles = await glob(pattern)
 
   // 테스트 파일 경로를 실제 Next.js 라우트로 변환
@@ -66,7 +100,6 @@ async function runTests(testFiles: string[]) {
 
   try {
     return new Promise<void>((resolve, reject) => {
-      // 브래킷이 포함된 파일 경로를 따옴표로 감싸서 shell glob 해석 방지
       const escapedTestFiles = testFiles.map((file) => `"${file}"`)
 
       const testProcess = spawn(
@@ -127,7 +160,7 @@ const buildManifest = JSON.parse(fs.readFileSync(buildManifestPath, "utf8"))
 
 // 실행 및 캐시 기반 테스트 실행
 async function main() {
-  const { testFiles, routes } = await findRoutes()
+  const { testFiles, routes } = await findTestRoutes()
   const cache = loadCache()
   const newCache: Record<string, string> = {}
   const testsToRun: string[] = []
@@ -138,73 +171,74 @@ async function main() {
     const route = routes[i]
     const testFile = testFiles[i]
 
-    const matchingKey = Object.keys(routeManifest).filter(
+    //client 파일 해시 계산
+    const matchingKey = Object.keys(routeManifest).find(
       (key) => routeManifest[key] === route,
-    )[0]
-    const buildFiles = buildManifest["pages"][matchingKey]
+    )
+
+    const buildFiles = buildManifest["pages"][matchingKey!]
+
+    let combinedContent = "" //전체 파일들을 모아서 해시 계산
 
     if (buildFiles && Array.isArray(buildFiles)) {
-      // 빌드 파일들의 내용을 읽어서 해시 생성
-      let combinedContent = ""
-
       buildFiles.forEach((file) => {
         try {
           const filePath = path.join(buildDir, file)
           const content = fs.readFileSync(filePath, "utf8")
-          combinedContent += content
+
+          combinedContent += parseSourceMap(content)
         } catch (error) {
           console.warn(`Warning: Could not read file ${file}:`, error)
         }
       })
+    }
+    //테스트파일 해시 계산
+    const testFileContent = fs.readFileSync(testFile, "utf8")
+    combinedContent += testFileContent
 
-      const testFileContent = fs.readFileSync(testFile, "utf8")
-      combinedContent += testFileContent
+    //서버 해시계산
+    const serverPagePath = path.join(buildDir, "server/app", route, "page.js")
+    const serverPageContent = fs.readFileSync(serverPagePath, "utf8")
 
-      const currentHash = crypto
-        .createHash("sha256")
-        .update(combinedContent)
-        .digest("hex")
+    if (serverPageContent) {
+      combinedContent += parseSourceMap(serverPageContent)
+    }
 
-      const cachedHash = cache[testFile]
+    const nftPath = path.join(buildDir, "server/app", route, "page.js.nft.json")
 
-      if (cachedHash === currentHash) {
-        console.log(`✅ Cache HIT: ${testFile} (${route})`)
-      } else {
-        console.log(`❌ Cache MISS: ${testFile} (${route})`)
-        testsToRun.push(testFile)
-      }
+    const nftJson = JSON.parse(fs.readFileSync(nftPath, "utf8"))
 
-      // 새 캐시에 현재 해시 저장
-      newCache[testFile] = currentHash
-    } else {
-      console.log(`⚠️  No build files found for route: ${route}`)
+    if (nftJson) {
+      // NFT 파일의 상대 경로는 빌드된 JS 파일의 디렉토리를 기준으로 함
+      const jsFileDir = path.dirname(nftPath)
 
-      // 빌드 파일이 없어도 테스트 파일 해시는 계산
-      try {
-        const testFileContent = fs.readFileSync(testFile, "utf8")
-        const currentHash = crypto
-          .createHash("sha256")
-          .update(testFileContent)
-          .digest("hex")
-
-        const cachedHash = cache[testFile]
-
-        if (cachedHash === currentHash) {
-          console.log(`✅ Cache HIT: ${testFile} (${route}) - test file only`)
-        } else {
-          console.log(
-            `❌ Cache MISS: ${testFile} (${route}) - test file changed`,
-          )
-          testsToRun.push(testFile)
+      nftJson["files"].forEach((file: string) => {
+        if (
+          file.includes("package.json") ||
+          file.includes("webpack-runtime.js") ||
+          file.includes("page_client-reference-manifest.js")
+        ) {
+          return
         }
 
-        newCache[testFile] = currentHash
-      } catch (error) {
-        console.warn(`Warning: Could not read test file ${testFile}:`, error)
-        // 테스트 파일을 읽을 수 없으면 실행
-        testsToRun.push(testFile)
-      }
+        const filePath = path.resolve(jsFileDir, file)
+        const content = fs.readFileSync(filePath, "utf8")
+
+        combinedContent += parseSourceMap(content) || content
+      })
     }
+
+    const currentHash = calculateHash(combinedContent)
+
+    if (cache[testFile] === currentHash) {
+      console.log(`✅ Cache HIT: ${testFile} (${route})`)
+    } else {
+      console.log(`❌ Cache MISS: ${testFile} (${route})`)
+
+      testsToRun.push(testFile)
+    }
+
+    newCache[testFile] = currentHash
   }
 
   console.log(`\n📊 Summary:`)

--- a/service/app/scripts/playwright.ts
+++ b/service/app/scripts/playwright.ts
@@ -1,0 +1,219 @@
+import crypto from "crypto"
+import fs from "fs"
+import { glob } from "glob"
+import path from "path"
+const { spawn } = await import("child_process")
+
+const buildDir = path.join(import.meta.dirname, "../.next")
+const cacheFile = path.join(import.meta.dirname, "../test-cache-map.json")
+
+async function findRoutes(pattern: string = "**/*.spec.ts") {
+  const testFiles = await glob(pattern)
+
+  // 테스트 파일 경로를 실제 Next.js 라우트로 변환
+  const routes = testFiles.map((filePath) => {
+    // src/app/ 이후의 경로를 추출
+    const appPath = filePath.replace(/^src\/app\//, "")
+
+    // __tests__ 폴더가 바로 시작되는 경우 (루트 경로)
+    if (appPath.startsWith("__tests__/")) {
+      return "/"
+    }
+
+    // __tests__ 폴더와 .spec.ts 파일 제거
+    const routePath = appPath
+      .replace(/\/__tests__\/.*$/, "") // __tests__ 폴더 이후 제거
+      .replace(/\.spec\.ts$/, "") // .spec.ts 확장자 제거
+
+    // 빈 문자열이면 루트 경로
+    if (!routePath) return "/"
+
+    // [gameId] 같은 동적 라우트는 그대로 유지
+    return `/${routePath}`
+  })
+
+  return {
+    testFiles,
+    routes,
+  }
+}
+
+// 캐시 파일 읽기
+function loadCache(): Record<string, string> {
+  try {
+    if (fs.existsSync(cacheFile)) {
+      const cacheContent = fs.readFileSync(cacheFile, "utf8")
+      return JSON.parse(cacheContent)
+    }
+  } catch (error) {
+    console.warn("Warning: Could not load cache file:", error)
+  }
+  return {}
+}
+
+// 캐시 파일 저장
+function saveCache(cache: Record<string, string>) {
+  try {
+    fs.writeFileSync(cacheFile, JSON.stringify(cache, null, 2))
+  } catch (error) {
+    console.error("Error: Could not save cache file:", error)
+  }
+}
+
+// 테스트 실행 함수 (모든 테스트를 한 번에 실행)
+async function runTests(testFiles: string[]) {
+  console.log(`🧪 Running tests: ${testFiles.join(", ")}`)
+
+  try {
+    return new Promise<void>((resolve, reject) => {
+      const testProcess = spawn(
+        "yarn",
+        ["playwright", "test", "--config=playwright.config.ts", ...testFiles],
+        {
+          stdio: "inherit",
+          cwd: import.meta.dirname + "/..",
+        },
+      )
+
+      testProcess.on("close", (code) => {
+        if (code === 0) {
+          console.log(`✅ All tests passed!`)
+          resolve()
+        } else {
+          console.log(`❌ Some tests failed (exit code: ${code})`)
+          reject(new Error(`Tests failed with exit code ${code}`))
+        }
+      })
+
+      testProcess.on("error", (error) => {
+        console.error(`Error running tests:`, error)
+        reject(error)
+      })
+    })
+  } catch (error) {
+    console.error(`Failed to run tests:`, error)
+    throw error
+  }
+}
+
+// Manifest 파일들이 존재하는지 확인
+const routeManifestPath = path.join(buildDir, "app-path-routes-manifest.json")
+const buildManifestPath = path.join(buildDir, "app-build-manifest.json")
+
+if (!fs.existsSync(routeManifestPath)) {
+  console.error(`❌ Route manifest file not found: ${routeManifestPath}`)
+  console.error("Please run 'yarn build' first to generate manifest files.")
+  process.exit(1)
+}
+
+if (!fs.existsSync(buildManifestPath)) {
+  console.error(`❌ Build manifest file not found: ${buildManifestPath}`)
+  console.error("Please run 'yarn build' first to generate manifest files.")
+  process.exit(1)
+}
+
+const routeManifest = JSON.parse(fs.readFileSync(routeManifestPath, "utf8"))
+
+const buildManifest = JSON.parse(fs.readFileSync(buildManifestPath, "utf8"))
+
+// 실행 및 캐시 기반 테스트 실행
+async function main() {
+  const { testFiles, routes } = await findRoutes()
+  const cache = loadCache()
+  const newCache: Record<string, string> = {}
+  const testsToRun: string[] = []
+
+  console.log("🔍 Checking test cache...")
+
+  for (let i = 0; i < routes.length; i++) {
+    const route = routes[i]
+    const testFile = testFiles[i]
+
+    const matchingKey = Object.keys(routeManifest).filter(
+      (key) => routeManifest[key] === route,
+    )[0]
+    const buildFiles = buildManifest["pages"][matchingKey]
+
+    if (buildFiles && Array.isArray(buildFiles)) {
+      // 빌드 파일들의 내용을 읽어서 해시 생성
+      let combinedContent = ""
+
+      buildFiles.forEach((file) => {
+        try {
+          const filePath = path.join(buildDir, file)
+          const content = fs.readFileSync(filePath, "utf8")
+          combinedContent += content
+        } catch (error) {
+          console.warn(`Warning: Could not read file ${file}:`, error)
+        }
+      })
+
+      const testFileContent = fs.readFileSync(testFile, "utf8")
+      combinedContent += testFileContent
+
+      const currentHash = crypto
+        .createHash("sha256")
+        .update(combinedContent)
+        .digest("hex")
+
+      const cachedHash = cache[testFile]
+
+      if (cachedHash === currentHash) {
+        console.log(`✅ Cache HIT: ${testFile} (${route})`)
+      } else {
+        console.log(`❌ Cache MISS: ${testFile} (${route})`)
+        testsToRun.push(testFile)
+      }
+
+      // 새 캐시에 현재 해시 저장
+      newCache[testFile] = currentHash
+    } else {
+      console.log(`⚠️  No build files found for route: ${route}`)
+
+      // 빌드 파일이 없어도 테스트 파일 해시는 계산
+      try {
+        const testFileContent = fs.readFileSync(testFile, "utf8")
+        const currentHash = crypto
+          .createHash("sha256")
+          .update(testFileContent)
+          .digest("hex")
+
+        const cachedHash = cache[testFile]
+
+        if (cachedHash === currentHash) {
+          console.log(`✅ Cache HIT: ${testFile} (${route}) - test file only`)
+        } else {
+          console.log(
+            `❌ Cache MISS: ${testFile} (${route}) - test file changed`,
+          )
+          testsToRun.push(testFile)
+        }
+
+        newCache[testFile] = currentHash
+      } catch (error) {
+        console.warn(`Warning: Could not read test file ${testFile}:`, error)
+        // 테스트 파일을 읽을 수 없으면 실행
+        testsToRun.push(testFile)
+      }
+    }
+  }
+
+  console.log(`\n📊 Summary:`)
+  console.log(`Total tests: ${testFiles.length}`)
+  console.log(`Tests to run: ${testsToRun.length}`)
+  console.log(`Cached tests: ${testFiles.length - testsToRun.length}`)
+
+  // 변경된 테스트만 실행
+  if (testsToRun.length > 0) {
+    console.log(`\n🧪 Running ${testsToRun.length} test(s)...`)
+    await runTests(testsToRun)
+  } else {
+    console.log(`\n🎉 All tests are cached! No tests to run.`)
+  }
+
+  // 캐시 파일 업데이트
+  saveCache(newCache)
+  console.log(`\n💾 Cache updated: ${cacheFile}`)
+}
+
+main().catch(console.error)

--- a/service/app/scripts/playwright.ts
+++ b/service/app/scripts/playwright.ts
@@ -100,7 +100,11 @@ async function runTests(testFiles: string[]) {
 
   try {
     return new Promise<void>((resolve, reject) => {
-      const escapedTestFiles = testFiles.map((file) => `"${file}"`)
+      const escapedTestFiles = testFiles.map((file) => {
+        // 대괄호만 escape 처리
+        const escaped = file.replace(/\[/g, "\\[").replace(/\]/g, "\\]")
+        return `"${escaped}"`
+      })
 
       const testProcess = spawn(
         "yarn",

--- a/service/app/scripts/playwright.ts
+++ b/service/app/scripts/playwright.ts
@@ -196,6 +196,47 @@ async function main() {
     const testFileContent = fs.readFileSync(testFile, "utf8")
     combinedContent += testFileContent
 
+    // 테스트코드에서 import하는 파일에 대한 해시 계시나
+    // POM을 찾는 것이 목적 - 간단하게 처리
+    const importPattern =
+      /(?:import\s+(?:{[^}]*}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g
+    let match
+    while ((match = importPattern.exec(testFileContent)) !== null) {
+      const importPath = match[1] || match[2]
+
+      if (
+        importPath &&
+        (importPath.startsWith("./") || importPath.startsWith("../"))
+      ) {
+        try {
+          const testFileDir = path.dirname(testFile)
+          const globPattern = path.resolve(testFileDir, importPath)
+
+          const files: string[] = []
+
+          const extensions = [".ts", ".tsx", ".js", ".jsx"]
+
+          extensions.forEach((ext) => {
+            const file = fs.existsSync(globPattern + ext)
+            if (file) {
+              files.push(globPattern + ext)
+            }
+          })
+
+          if (files.length > 0) {
+            const actualPath = path.resolve(testFileDir, files[0])
+            const importContent = fs.readFileSync(actualPath, "utf8")
+            combinedContent += importContent
+          }
+        } catch (error) {
+          console.warn(
+            `Warning: Could not read import file ${importPath}:`,
+            error,
+          )
+        }
+      }
+    }
+
     //서버 해시계산
     const serverPagePath = path.join(buildDir, "server/app", route, "page.js")
     const serverPageContent = fs.readFileSync(serverPagePath, "utf8")

--- a/service/app/src/app/dashboard/__tests__/dashboard.spec.ts
+++ b/service/app/src/app/dashboard/__tests__/dashboard.spec.ts
@@ -31,14 +31,18 @@ class DashboardPage {
 
     // 네비게이션 버튼들
     this.homeButton = page.getByRole("button", { name: "홈으로 이동" })
-    this.createGameButton = page.getByRole("button", { name: "게임 만들기" }).first()
+    this.createGameButton = page
+      .getByRole("button", { name: "게임 만들기" })
+      .first()
 
     // 사용자 메뉴 관련
-    this.avatarButton = page.getByRole("button", { name: /테스트 사용자 메뉴 (열기|닫기)/ })
+    this.avatarButton = page.getByRole("button", {
+      name: /테스트 사용자 메뉴 (열기|닫기)/,
+    })
     this.logoutButton = page.getByRole("menuitem", { name: "로그아웃" })
 
     // 게임 카드 관련
-    this.gameCards = page.locator('[data-testid="game-card"]')
+    this.gameCards = page.getByTestId("game-card")
     this.gameOptionsButtons = page.getByRole("button", { name: "게임 옵션" })
 
     // 팝업 관련
@@ -49,12 +53,7 @@ class DashboardPage {
   async getFirstSharedGameIndex(): Promise<number | null> {
     const count = await this.gameCards.count()
     for (let i = 0; i < count; i++) {
-      if (
-        await this.gameCards
-          .nth(i)
-          .locator('[data-testid="shared-badge"]')
-          .isVisible()
-      ) {
+      if (await this.gameCards.nth(i).getByTestId("shared-badge").isVisible()) {
         return i
       }
     }
@@ -65,10 +64,7 @@ class DashboardPage {
     const count = await this.gameCards.count()
     for (let i = 0; i < count; i++) {
       if (
-        !(await this.gameCards
-          .nth(i)
-          .locator('[data-testid="shared-badge"]')
-          .isVisible())
+        !(await this.gameCards.nth(i).getByTestId("shared-badge").isVisible())
       ) {
         return i
       }
@@ -78,12 +74,9 @@ class DashboardPage {
 
   // 페이지 이동 메서드
   async goto() {
-    await this.page.goto("http://localhost:3000/dashboard")
-    await this.page.waitForLoadState("networkidle")
+    await this.page.goto("/dashboard")
     // 게임 카드가 로드될 때까지 기다림
-    await this.page.waitForSelector('[data-testid="game-card"]', { timeout: 10000 }).catch(() => {
-      console.warn("No game cards found after 10s")
-    })
+    await this.page.getByTestId("game-card").first().waitFor({ timeout: 10000 })
   }
 
   // 네비게이션 액션 메서드들
@@ -110,8 +103,10 @@ class DashboardPage {
 
   async clickGameOptionsButton(index: number | null = 0) {
     const idx = index ?? 0
-    await this.gameCards.nth(idx).waitFor({ state: 'visible', timeout: 10000 })
-    await this.gameOptionsButtons.nth(idx).waitFor({ state: 'visible', timeout: 10000 })
+    await this.gameCards.nth(idx).waitFor({ state: "visible", timeout: 10000 })
+    await this.gameOptionsButtons
+      .nth(idx)
+      .waitFor({ state: "visible", timeout: 10000 })
     await this.gameOptionsButtons.nth(idx).click()
   }
 
@@ -139,7 +134,7 @@ class DashboardPage {
   }
 
   async clickGamePreviewCloseArea() {
-    await this.gamePreviewDialog.locator('[data-testid="close-area"]').click()
+    await this.gamePreviewDialog.getByTestId("close-area").click()
   }
 
   async clickGameStartButton() {
@@ -158,23 +153,25 @@ class DashboardPage {
   }
 
   async clickAlertCloseArea() {
-    await this.alertDialog.locator('[data-testid="close-area"]').click()
+    await this.alertDialog.getByTestId("close-area").click()
   }
 
   // 검증 메서드들
   async expectToBeOnHomePage() {
-    await this.page.waitForURL("http://localhost:3000/", { timeout: 10000 })
-    await expect(this.page).toHaveURL("http://localhost:3000/")
+    await this.page.waitForURL("/", { timeout: 10000 })
+    await expect(this.page).toHaveURL("/")
   }
 
   async expectToBeOnCreatePage() {
-    await this.page.waitForURL(/^http:\/\/localhost:3000\/create(\?gameId=\d+)?$/, { timeout: 10000 })
-    await expect(this.page).toHaveURL(/^http:\/\/localhost:3000\/create(\?gameId=\d+)?$/)
+    await this.page.waitForURL(/\/create(\?gameId=\d+)?$/, { timeout: 10000 })
+    await expect(this.page).toHaveURL(/\/create(\?gameId=\d+)?$/)
   }
 
   async expectToBeOnDashboardPage() {
-    await this.page.waitForURL("http://localhost:3000/dashboard", { timeout: 10000 })
-    await expect(this.page).toHaveURL("http://localhost:3000/dashboard")
+    await this.page.waitForURL("/dashboard", {
+      timeout: 10000,
+    })
+    await expect(this.page).toHaveURL("/dashboard")
   }
 
   async expectToBeOnGameSetupPage() {
@@ -197,17 +194,13 @@ class DashboardPage {
     await expect(gameCard).toBeVisible()
 
     // 게임 제목이 표시되어야 한다
-    await expect(gameCard.locator('[data-testid="game-title"]')).toBeVisible()
+    await expect(gameCard.getByTestId("game-title")).toBeVisible()
 
     // 문제 개수가 표시되어야 한다
-    await expect(
-      gameCard.locator('[data-testid="question-count"]'),
-    ).toBeVisible()
+    await expect(gameCard.getByTestId("question-count")).toBeVisible()
 
     // 게임 옵션 버튼이 표시되어야 한다
-    await expect(
-      gameCard.locator('[data-testid="game-options-button"]'),
-    ).toBeVisible()
+    await expect(gameCard.getByTestId("game-options-button")).toBeVisible()
   }
 
   async expectGamePreviewInfo() {
@@ -235,31 +228,27 @@ class DashboardPage {
   async expectSharedBadge(index: number | null = 0) {
     const idx = index ?? 0
     const gameCard = this.gameCards.nth(idx)
-    await expect(gameCard.locator('[data-testid="shared-badge"]')).toBeVisible()
+    await expect(gameCard.getByTestId("shared-badge")).toBeVisible()
   }
 
   async expectNoSharedBadge(index: number | null = 0) {
     const idx = index ?? 0
     const gameCard = this.gameCards.nth(idx)
-    await expect(
-      gameCard.locator('[data-testid="shared-badge"]'),
-    ).not.toBeVisible()
+    await expect(gameCard.getByTestId("shared-badge")).not.toBeVisible()
   }
 
   async expectNoSharedBadgeByTitle(gameTitle: string) {
-    const gameCard = this.page.locator(
-      `[data-testid="game-card"]:has-text("${gameTitle}")`,
-    )
-    await expect(
-      gameCard.locator('[data-testid="shared-badge"]'),
-    ).not.toBeVisible()
+    const gameCard = this.page
+      .getByTestId("game-card")
+      .filter({ hasText: gameTitle })
+    await expect(gameCard.getByTestId("shared-badge")).not.toBeVisible()
   }
 
   async expectSharedBadgeByTitle(gameTitle: string) {
-    const gameCard = this.page.locator(
-      `[data-testid="game-card"]:has-text("${gameTitle}")`,
-    )
-    await expect(gameCard.locator('[data-testid="shared-badge"]')).toBeVisible()
+    const gameCard = this.page
+      .getByTestId("game-card")
+      .filter({ hasText: gameTitle })
+    await expect(gameCard.getByTestId("shared-badge")).toBeVisible()
   }
 
   async expectGameOptionsMenu(index: number = 0) {
@@ -270,7 +259,7 @@ class DashboardPage {
 
     const isShared = await this.gameCards
       .nth(index)
-      .locator('[data-testid="shared-badge"]')
+      .getByTestId("shared-badge")
       .isVisible()
     if (isShared) {
       await expect(
@@ -305,8 +294,21 @@ class DashboardPage {
 test.describe("대시보드 E2E 테스트 - 기본 UI 확인", () => {
   let dashboardPage: DashboardPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     dashboardPage = new DashboardPage(page)
+
+    // 쿠키 설정
+    await context.addCookies([
+      {
+        name: "JSESSIONID",
+        value: "test-session-123",
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+      },
+    ])
+
+    // localStorage 설정
     await page.addInitScript(() => {
       localStorage.setItem(
         "auth_user",
@@ -316,8 +318,8 @@ test.describe("대시보드 E2E 테스트 - 기본 UI 확인", () => {
           email: "test@example.com",
         }),
       )
-      document.cookie = "JSESSIONID=test-session-123; Path=/; SameSite=Lax"
     })
+
     await dashboardPage.goto()
   })
 
@@ -334,8 +336,21 @@ test.describe("대시보드 E2E 테스트 - 기본 UI 확인", () => {
 test.describe("대시보드 E2E 테스트 - 네비게이션 기능", () => {
   let dashboardPage: DashboardPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     dashboardPage = new DashboardPage(page)
+
+    // 쿠키 설정
+    await context.addCookies([
+      {
+        name: "JSESSIONID",
+        value: "test-session-123",
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+      },
+    ])
+
+    // localStorage 설정
     await page.addInitScript(() => {
       localStorage.setItem(
         "auth_user",
@@ -345,8 +360,8 @@ test.describe("대시보드 E2E 테스트 - 네비게이션 기능", () => {
           email: "test@example.com",
         }),
       )
-      document.cookie = "JSESSIONID=test-session-123; Path=/; SameSite=Lax"
     })
+
     await dashboardPage.goto()
   })
 
@@ -365,8 +380,21 @@ test.describe("대시보드 E2E 테스트 - 네비게이션 기능", () => {
 test.describe("대시보드 E2E 테스트 - 게임 카드 기능", () => {
   let dashboardPage: DashboardPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     dashboardPage = new DashboardPage(page)
+
+    // 쿠키 설정
+    await context.addCookies([
+      {
+        name: "JSESSIONID",
+        value: "test-session-123",
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+      },
+    ])
+
+    // localStorage 설정
     await page.addInitScript(() => {
       localStorage.setItem(
         "auth_user",
@@ -376,8 +404,8 @@ test.describe("대시보드 E2E 테스트 - 게임 카드 기능", () => {
           email: "test@example.com",
         }),
       )
-      document.cookie = "JSESSIONID=test-session-123; Path=/; SameSite=Lax"
     })
+
     await dashboardPage.goto()
   })
 
@@ -407,8 +435,21 @@ test.describe("대시보드 E2E 테스트 - 게임 카드 기능", () => {
 test.describe("대시보드 E2E 테스트 - 게임 옵션 메뉴", () => {
   let dashboardPage: DashboardPage
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     dashboardPage = new DashboardPage(page)
+
+    // 쿠키 설정
+    await context.addCookies([
+      {
+        name: "JSESSIONID",
+        value: "test-session-123",
+        domain: "localhost",
+        path: "/",
+        sameSite: "Lax",
+      },
+    ])
+
+    // localStorage 설정
     await page.addInitScript(() => {
       localStorage.setItem(
         "auth_user",
@@ -418,8 +459,8 @@ test.describe("대시보드 E2E 테스트 - 게임 옵션 메뉴", () => {
           email: "test@example.com",
         }),
       )
-      document.cookie = "JSESSIONID=test-session-123; Path=/; SameSite=Lax"
     })
+
     await dashboardPage.goto()
   })
 
@@ -517,9 +558,9 @@ test.describe("대시보드 E2E 테스트 - Alert 팝업", () => {
     // 게임 제목을 미리 저장
     const gameTitle = await dashboardPage.gameCards
       .nth(sharedIdx!)
-      .locator('[data-testid="game-title"]')
+      .getByTestId("game-title")
       .textContent()
-    if (!gameTitle) test.skip()
+    expect(gameTitle).toBeTruthy() // 게임 제목이 없으면 테스트 실패
 
     await dashboardPage.clickGameOptionsButton(sharedIdx!)
     await dashboardPage.clickGameUnshareButton()
@@ -542,9 +583,9 @@ test.describe("대시보드 E2E 테스트 - Alert 팝업", () => {
     // 첫 번째 게임의 제목을 미리 저장
     const firstGameTitle = await dashboardPage.gameCards
       .nth(0)
-      .locator('[data-testid="game-title"]')
+      .getByTestId("game-title")
       .textContent()
-    if (!firstGameTitle) test.skip()
+    expect(firstGameTitle).toBeTruthy() // 게임 제목이 없으면 테스트 실패
 
     await dashboardPage.clickGameOptionsButton()
     await dashboardPage.clickGameDeleteButton()
@@ -558,9 +599,9 @@ test.describe("대시보드 E2E 테스트 - Alert 팝업", () => {
 
     // 삭제된 게임이 화면에서 사라졌는지 확인
     await expect(
-      dashboardPage.page.locator(
-        `[data-testid="game-card"]:has-text("${firstGameTitle}")`,
-      ),
+      dashboardPage.page
+        .getByTestId("game-card")
+        .filter({ hasText: firstGameTitle! }),
     ).not.toBeVisible()
   })
 })

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -16,7 +16,6 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
 
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-center">
-      {/* Question Text */}
       <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
         {currentQuestion.questionText}
       </h1>
@@ -36,7 +35,6 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
         </div>
       )}
 
-      {/* Answer Section */}
       {showAnswer ? (
         <SecondaryOutlineBoxButton
           size="lg"

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -13,10 +13,12 @@ interface GamePlayContentProps {
 
 export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
   const [showAnswer, setShowAnswer] = useState(false)
-
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-center">
-      <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
+      <h1
+        className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary"
+        id="special"
+      >
         {currentQuestion.questionText}
       </h1>
 
@@ -39,6 +41,7 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
         <SecondaryOutlineBoxButton
           size="lg"
           onClick={() => setShowAnswer(false)}
+          aria-label="wefwefwef"
         >
           {currentQuestion?.questionAnswer}
         </SecondaryOutlineBoxButton>

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -13,12 +13,10 @@ interface GamePlayContentProps {
 
 export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
   const [showAnswer, setShowAnswer] = useState(false)
+
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-center">
-      <h1
-        className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary"
-        id="special"
-      >
+      <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
         {currentQuestion.questionText}
       </h1>
 
@@ -41,7 +39,6 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
         <SecondaryOutlineBoxButton
           size="lg"
           onClick={() => setShowAnswer(false)}
-          aria-label="wefwefwef"
         >
           {currentQuestion?.questionAnswer}
         </SecondaryOutlineBoxButton>

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
@@ -23,7 +23,7 @@ export const GamePlayHeader = ({
   onExit,
 }: GamePlayHeaderProps) => {
   return (
-    <div className="mx-auto flex h-[110px] w-full shrink-0 items-center justify-between">
+    <header className="mx-auto flex h-[110px] w-full shrink-0 items-center justify-between">
       <div className="flex w-[420px] items-center gap-[10px] self-stretch px-[40px]">
         <button
           onClick={onExit}
@@ -72,6 +72,6 @@ export const GamePlayHeader = ({
           </SecondaryPlainIconButton>
         </div>
       </div>
-    </div>
+    </header>
   )
 }

--- a/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
+++ b/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
@@ -19,7 +19,7 @@ export class GameSetupPOM {
     this.startButton = page.getByRole("button", { name: "게임 시작" })
   }
 
-  async goto(gameId: string = "1") {
+  async goto(gameId: string = "2") {
     await this.page.goto(`game/${gameId}/setup`)
     await this.page.waitForLoadState("networkidle")
   }

--- a/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
+++ b/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
@@ -19,7 +19,7 @@ export class GameSetupPOM {
     this.startButton = page.getByRole("button", { name: "게임 시작" })
   }
 
-  async goto(gameId: string = "2") {
+  async goto(gameId: string = "1") {
     await this.page.goto(`game/${gameId}/setup`)
     await this.page.waitForLoadState("networkidle")
   }

--- a/service/app/src/mocks/mswProvider.tsx
+++ b/service/app/src/mocks/mswProvider.tsx
@@ -13,7 +13,7 @@ export const useMsw = () => useContext(MSWContext)
 
 export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
   const [isMswReady, setIsMswReady] = useState(
-    process.env.NODE_ENV === "production" || !!process.env.NEXT_PUBLIC_TEST,
+    process.env.NODE_ENV === "production",
   )
   const [isMswError, setIsMswError] = useState(false)
 
@@ -22,7 +22,7 @@ export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
       try {
         if (
           process.env.NODE_ENV !== "production" ||
-          !process.env.NEXT_PUBLIC_TEST
+          process.env.NEXT_PUBLIC_TEST //테스트 환경에서 msw활용을 위해 주입되는 환경변수
         ) {
           const { initMsw } = await import("./index")
           await initMsw()

--- a/service/app/src/mocks/mswProvider.tsx
+++ b/service/app/src/mocks/mswProvider.tsx
@@ -13,14 +13,17 @@ export const useMsw = () => useContext(MSWContext)
 
 export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
   const [isMswReady, setIsMswReady] = useState(
-    process.env.NODE_ENV === "production",
+    process.env.NODE_ENV === "production" || !!process.env.NEXT_PUBLIC_TEST,
   )
   const [isMswError, setIsMswError] = useState(false)
 
   useEffect(() => {
     const init = async () => {
       try {
-        if (process.env.NODE_ENV !== "production") {
+        if (
+          process.env.NODE_ENV !== "production" ||
+          !process.env.NEXT_PUBLIC_TEST
+        ) {
           const { initMsw } = await import("./index")
           await initMsw()
         }

--- a/service/app/tsconfig.json
+++ b/service/app/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "target": "es2023",
     "noImplicitAny": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,6 +1399,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -1445,6 +1461,7 @@ __metadata:
     "@vitest/browser": "npm:^3.2.4"
     autoprefixer: "npm:^10.4.21"
     es-toolkit: "npm:^1.39.8"
+    glob: "npm:^11.0.3"
     immer: "npm:^10.1.1"
     msw: "npm:^2.10.3"
     next: "npm:^14.2"
@@ -7251,7 +7268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0":
+"foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -7528,6 +7545,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "glob@npm:11.0.3"
+  dependencies:
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.0.3"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/7d24457549ec2903920dfa3d8e76850e7c02aa709122f0164b240c712f5455c0b457e6f2a1eee39344c6148e39895be8094ae8cfef7ccc3296ed30bce250c661
   languageName: node
   linkType: hard
 
@@ -8388,6 +8421,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "jackspeak@npm:4.1.1"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/84ec4f8e21d6514db24737d9caf65361511f75e5e424980eebca4199f400874f45e562ac20fa8aeb1dd20ca2f3f81f0788b6e9c3e64d216a5794fd6f30e0e042
+  languageName: node
+  linkType: hard
+
 "jake@npm:^10.8.5":
   version: 10.9.2
   resolution: "jake@npm:10.9.2"
@@ -8845,6 +8887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -9064,6 +9113,15 @@ __metadata:
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "minimatch@npm:10.0.3"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
   languageName: node
   linkType: hard
 
@@ -9895,6 +9953,16 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 설명
Playwright E2E 테스트 캐시 적용
- E2E 테스트에 캐시 기능을 추가하여, 로직 변경이 없는 경우 테스트를 자동으로 건너뛰도록 구현했습니다.
- 로직 변경을 판단하는 것은 next build output을 활용합니다(서버,클라이언트 로직 모두 고려)

### 중요한점
- e2e test 파일컨벤션에 따라 작성된 파일만 테스트 대상으로 삼게 됩니다
예를 들어 `src/app/create/__tests__/a.spec.ts` -> create페이지에 대한 e2e 테스트 코드로 간주하고, `/create` 의 로직 변경이 없을 시 캐시 활용 및 테스트 자체가 실행되지 않음

## 주요 변경 사항
### 1. 환경 설정

* `NEXT_PUBLIC_TEST` 환경변수 추가

  * CI 환경에서만 주입
  * 테스트 환경 구분에 활용

### 2. 캐시 기능

* `.next` 폴더 내 서버/클라이언트 번들, 청크, 테스트 코드, POM 참조 파일을 해시하여 캐시 hit/miss 판단
* 캐시 key 저장: GitHub Actions `@actions/cache` 활용
* 조건부 렌더링 로직 변경 시 번들에 포함되지 않는 것으로 확인됨 -> 캐시가 무효화되지 않음

### 3. 빌드 및 테스트 실행 변경

* `.next` 폴더 활용을 위해 테스트 전에 빌드과정을 거치게 됨
* playwright test 서버 실행 명령어 변경:

  ```bash
  yarn dev → yarn start
  ```
  - dev에서는 그대로
* Next.js 비결정적 빌드로 인해 같은 로직이어도 빌드 결과가 달라질 수 있어 테스트 빌드 시 sourcemap 옵션 활성화 → sourcemap 기반 캐시 판단

### 4. 캐시 관리

* 테스트가 필요함에도 캐시 hit가 발생하면, `actions/cache`에서 `e2e-tests-[숫자]` 로 중 가장 최신 데이터를 삭제 후 재실행
- 추후에 force 옵션 등을 만들어 보겠습니다

### 5. 기타 수정 사항

* `yarn start`로 실행되는 테스트 과정에서 발생하는 flaky test 일부 수정 [8c7d5bf](https://github.com/JECT-Study/JECT-5-FE/pull/160/commits/8c7d5bf8ce5fb5cbe5b538b60fff6a7a8015c862)
* production이지만 테스트 환경에서 msw를 활용하기 위해 msw provider 조건 일부 수정

---
- 스타일
  - 게임 플레이 내비게이션을 시맨틱 header로 전환하고 특정 제목에 id 및 보조 버튼 aria-label 추가

- 테스트
  - 대시보드 E2E를 test-id 기반으로 정리하고 인증을 쿠키/로컬스토리지로 주입해 일관화
  - 상대 경로 URL 검증 표준화
  - 선택적 E2E 실행과 파일 기반 해시 캐시로 불필요한 테스트 건너뜀

- 리팩터
  - 로컬/CI에 따라 테스트 서버 시작 방식 분기
  - 기본 테스트 대상 기본값 변경

- 잡무(Chores)
  - CI에 E2E 빌드·준비·캐시 단계 추가 및 PR 성공 코멘트 제거
  - MSW 초기화 조건 확장, TypeScript 타깃 업데이트 및 개발 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->