### PR TITLE
question 컴포넌트 접근성 관련 태그 작성

### DIFF
--- a/service/app/src/entities/game/ui/components/questionList.tsx
+++ b/service/app/src/entities/game/ui/components/questionList.tsx
@@ -16,12 +16,12 @@ export function QuestionList() {
       aria-label="게임 문제 목록"
     >
       <div className="flex w-[350px] flex-col items-start gap-6">
-        {state.questions.map((question, index) => {
+        {state.questions.map((question) => {
           const questionSelectors = getQuestionSelectors(question.id)
           const isSelected = questionSelectors.isSelected
 
           return (
-            <div key={question.id} data-testid={`question-item-${index}`}>
+            <div key={question.id}>
               <Question
                 state={
                   isSelected

--- a/service/app/src/entities/game/ui/components/questionList.tsx
+++ b/service/app/src/entities/game/ui/components/questionList.tsx
@@ -14,7 +14,6 @@ export function QuestionList() {
       className="flex w-[400px] flex-col items-center bg-background-tertiary p-[25px_25px_0_25px]"
       role="list"
       aria-label="게임 문제 목록"
-      data-testid="question-list"
     >
       <div className="flex w-[350px] flex-col items-start gap-6">
         {state.questions.map((question, index) => {

--- a/service/app/src/entities/game/ui/components/questionList.tsx
+++ b/service/app/src/entities/game/ui/components/questionList.tsx
@@ -22,15 +22,15 @@ export function QuestionList() {
           const isSelected = questionSelectors.isSelected
 
           return (
-            <div
-              key={question.id}
-              role="listitem"
-              aria-label={`문제 ${index + 1}: ${question.text || "질문을 입력해주세요"}`}
-              data-testid={`question-item-${index}`}
-            >
+            <div key={question.id} data-testid={`question-item-${index}`}>
               <Question
-                state={isSelected ? "selected" : "default"}
-                hasError={!validateQuestion(question)}
+                state={
+                  isSelected
+                    ? "selected"
+                    : !validateQuestion(question)
+                      ? "error"
+                      : "default"
+                }
                 onClick={() => actions.selectQuestion(question.id)}
               >
                 <Question.Title>

--- a/service/app/src/entities/game/ui/components/questionList.tsx
+++ b/service/app/src/entities/game/ui/components/questionList.tsx
@@ -16,13 +16,14 @@ export function QuestionList() {
       aria-label="게임 문제 목록"
     >
       <div className="flex w-[350px] flex-col items-start gap-6">
-        {state.questions.map((question) => {
+        {state.questions.map((question, index) => {
           const questionSelectors = getQuestionSelectors(question.id)
           const isSelected = questionSelectors.isSelected
 
           return (
             <div key={question.id}>
               <Question
+                index={index + 1}
                 state={
                   isSelected
                     ? "selected"

--- a/shared/design/src/components/question/README.md
+++ b/shared/design/src/components/question/README.md
@@ -158,11 +158,12 @@ Question
 
 #### `aria-label={accessibleName}`
 - **목적**: 각 질문 카드를 구체적으로 구분할 수 있는 접근 가능한 이름 제공
-- **값**: `title ? \`질문: ${title}\` : "질문 카드"`
+- **값**: `index ? \`${index}번째 문제\` : "질문 카드"`
 - **이유**: 
-  - 스크린 리더 사용자가 어떤 질문인지 즉시 파악 가능
-  - E2E 테스트에서 특정 질문을 정확히 선택 가능
-- **E2E 테스트**: `page.getByRole('group', { name: '질문: 첫 번째 문제입니다' })`로 특정 질문 선택
+  - **순서 기반 식별**: 질문 내용 대신 순서로 식별하여 더 안정적이고 간결함
+  - **동적 업데이트**: 질문 순서가 변경되면 자동으로 라벨도 업데이트됨
+  - **E2E 테스트 안정성**: 질문 내용이 바뀌어도 순서 기반으로 안정적인 선택 가능
+- **E2E 테스트**: `page.getByRole('group', { name: '1번째 문제' })`로 첫 번째 질문 선택
 
 #### `data-state={state}`
 - **목적**: 질문의 현재 상태를 명시적으로 표현
@@ -198,15 +199,16 @@ Question
 #### `aria-label` 속성 (모든 아이콘 버튼)
 - **목적**: 텍스트가 없는 아이콘 버튼에 명확한 기능 설명 제공
 - **값**: 
-  - 삭제 버튼: `"${title} 질문 삭제"` 또는 `"질문 삭제"`
-  - 위로 이동: `"${title} 질문 위로 이동"` 또는 `"질문 위로 이동"`
-  - 아래로 이동: `"${title} 질문 아래로 이동"` 또는 `"질문 아래로 이동"`
+  - 삭제 버튼: `"${index}번째 문제 삭제"` 또는 `"질문 삭제"`
+  - 위로 이동: `"${index}번째 문제 위로 이동"` 또는 `"질문 위로 이동"`
+  - 아래로 이동: `"${index}번째 문제 아래로 이동"` 또는 `"질문 아래로 이동"`
 - **이유**:
   - **아이콘만으로는 기능을 알 수 없음**: Trash, Arrow 아이콘만으로는 구체적인 동작을 파악하기 어려움
   - **스크린 리더 지원**: 시각적 정보에 의존할 수 없는 사용자를 위한 필수 정보
-  - **구체적인 컨텍스트 제공**: 어떤 질문에 대한 동작인지 명확히 표시
+  - **순서 기반 컨텍스트**: 질문 내용 대신 순서로 어떤 문제에 대한 동작인지 명확히 표시
+  - **동적 업데이트**: 질문 순서 변경 시 버튼 라벨도 자동으로 업데이트됨
   - **E2E 테스트 안정성**: 버튼의 시각적 위치나 아이콘 이미지가 변경되어도 기능 기반으로 선택 가능
-- **E2E 테스트**: `page.getByRole('button', { name: '첫 번째 문제 질문 삭제' })`
+- **E2E 테스트**: `page.getByRole('button', { name: '1번째 문제 삭제' })`
 
 ### 3. **Radix UI와의 호환성 고려사항**
 
@@ -225,6 +227,45 @@ Question
 **`aria-label` (버튼에서 유지)**
 - **이유**: Radix UI의 BaseButton이 표준 HTML `<button>` 요소를 사용하므로 안전
 - **근거**: HTML 표준에서 button 요소의 `aria-label`은 공식 지원 속성
+
+### 4. **순서 기반 접근성의 장점**
+
+#### **동적 업데이트 지원**
+```typescript
+// QuestionList에서 질문 순서 변경 시
+{state.questions.map((question, index) => (
+  <Question 
+    index={index + 1}  // 배열 순서에 따라 자동 업데이트
+    state={...}
+  >
+    <Question.Title>{question.text}</Question.Title>
+  </Question>
+))}
+```
+
+**Before (순서 변경 전):**
+- "1번째 문제" (첫 번째 질문)
+- "2번째 문제" (두 번째 질문)  
+- "3번째 문제" (세 번째 질문)
+
+**After (두 번째 질문을 첫 번째로 이동):**
+- "1번째 문제" (원래 두 번째였던 질문) ✅ 자동 업데이트
+- "2번째 문제" (원래 첫 번째였던 질문) ✅ 자동 업데이트
+- "3번째 문제" (세 번째 질문 그대로)
+
+#### **E2E 테스트에서의 활용**
+```typescript
+// 순서 기반으로 안정적인 테스트 작성
+test('질문 순서 변경', async ({ page }) => {
+  // 2번째 문제를 위로 이동
+  await page.getByRole('button', { name: '2번째 문제 위로 이동' }).click()
+  
+  // 순서가 바뀐 후 첫 번째 질문 확인 (자동으로 라벨 업데이트됨)
+  await expect(page.getByRole('group', { name: '1번째 문제' })).toBeVisible()
+})
+```
+
+이러한 순서 기반 접근성 설계를 통해 Question 컴포넌트는 스크린 리더 사용자와 E2E 테스트 모두에서 안정적이고 예측 가능한 동작을 보장합니다.
 
 
 ## 🔄 Figma 디자인 대비 리팩토링 변경사항
@@ -306,6 +347,7 @@ COMPONENT_SET "question"
 ```typescript
 interface QuestionRootProps {
   state: "default" | "selected" | "error"
+  index?: number      // 순서 기반 접근성 (1부터 시작)
   onClick?: () => void // 인터랙션 지원
   // image (boolean) 속성 삭제
 }
@@ -313,7 +355,8 @@ interface QuestionRootProps {
 
 **이유:**
 - **동적 상태**: 런타임에 상태 변경 가능, `state="error"`로 에러 처리 통합
-- **자동 접근성**: `Question.Title`에서 자동으로 접근성 라벨 생성
+- **순서 기반 접근성**: `index` prop으로 "n번째 문제" 라벨 자동 생성
+- **동적 업데이트**: 질문 순서 변경 시 접근성 라벨도 자동 업데이트
 - **인터랙션**: 클릭 등 사용자 상호작용 지원
 - 합성 컴포넌트 패턴으로 충분히 처리 가능한 불필요한 속성 (image) 삭제
 
@@ -374,11 +417,16 @@ interface QuestionRootProps {
 
 **변경 후 (현재):**
 ```typescript
-<Question state="selected" onClick={handleClick}>
-  <Question.Title>사용자 정의 제목</Question.Title>  {/* 자동으로 접근성 라벨로 사용됨 */}
+<Question index={1} state="selected" onClick={handleClick}>  {/* index로 순서 기반 접근성 */}
+  <Question.Title>사용자 정의 제목</Question.Title>
   <Question.Image fallback={<CustomFallback />} />
   <Question.DeleteButton canDelete={canDelete} onDelete={onDelete} />
 </Question>
 ```
+
+**접근성 라벨 결과:**
+- Question 카드: `aria-label="1번째 문제"`
+- 삭제 버튼: `aria-label="1번째 문제 삭제"`
+- 이동 버튼: `aria-label="1번째 문제 위로 이동"`
 
 

--- a/shared/design/src/components/question/README.md
+++ b/shared/design/src/components/question/README.md
@@ -256,7 +256,7 @@ COMPONENT_SET "question"
 
 ```typescript
 // 현재 구현
-<Question state="default" title="첫 번째 질문">
+<Question state="default">
   <Question.Title>첫 번째 질문</Question.Title>
   <Question.Image>
     <img src="/image.jpg" alt="질문 이미지" />
@@ -306,14 +306,14 @@ COMPONENT_SET "question"
 ```typescript
 interface QuestionRootProps {
   state: "default" | "selected" | "error"
-  title?: string      // 접근성을 위한 제목
   onClick?: () => void // 인터랙션 지원
   // image (boolean) 속성 삭제
 }
 ```
 
 **이유:**
-- **동적 상태**: 런타임에 상태 변경 가능
+- **동적 상태**: 런타임에 상태 변경 가능, `state="error"`로 에러 처리 통합
+- **자동 접근성**: `Question.Title`에서 자동으로 접근성 라벨 생성
 - **인터랙션**: 클릭 등 사용자 상호작용 지원
 - 합성 컴포넌트 패턴으로 충분히 처리 가능한 불필요한 속성 (image) 삭제
 
@@ -322,7 +322,7 @@ interface QuestionRootProps {
 **변경 후 (현재):**
 ```typescript
 // shared/design 패키지에서는 일반 img 태그 사용 (Next.js 독립적)
-<Question state="default" title="질문 제목">
+<Question state="default">
   <Question.Image>
     <img 
       src="/question-images/sample.jpg"
@@ -345,7 +345,7 @@ interface QuestionRootProps {
 } />
 
 // service/app에서 Next.js Image 사용 시
-<Question state="default" title="질문 제목">
+<Question state="default">
   <Question.Image>
     <Image 
       src="/question-images/sample.jpg"
@@ -374,8 +374,8 @@ interface QuestionRootProps {
 
 **변경 후 (현재):**
 ```typescript
-<Question state="selected" title="질문 제목" onClick={handleClick}>
-  <Question.Title>사용자 정의 제목</Question.Title>
+<Question state="selected" onClick={handleClick}>
+  <Question.Title>사용자 정의 제목</Question.Title>  {/* 자동으로 접근성 라벨로 사용됨 */}
   <Question.Image fallback={<CustomFallback />} />
   <Question.DeleteButton canDelete={canDelete} onDelete={onDelete} />
 </Question>

--- a/shared/design/src/components/question/README.md
+++ b/shared/design/src/components/question/README.md
@@ -1,0 +1,384 @@
+# Question 컴포넌트 - Radix UI 기반 컴포넌트 구조
+
+## 🏗️ Radix UI 기반 컴포넌트 구조
+
+Question 컴포넌트는 내부적으로 여러 Radix UI 기반 컴포넌트들을 사용하여 구성되어 있습니다.
+
+### 1. **BaseButton (Radix UI Slot 기반)**
+
+모든 버튼 컴포넌트의 기반이 되는 `BaseButton`은 Radix UI의 `Slot` primitive를 사용합니다:
+
+```typescript
+// shared/design/src/components/button/baseButton.tsx
+import { Slot } from "radix-ui"
+import { type ComponentPropsWithoutRef, forwardRef } from "react"
+
+export type BaseButtonProps = ComponentPropsWithoutRef<"button"> & {
+  asChild?: boolean
+}
+
+export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
+  ({ asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot.Root : "button"
+    return <Comp ref={ref} data-slot="button" {...props} />
+  },
+)
+```
+
+### 2. **DestructiveSolidIconButton**
+
+Question 컴포넌트의 삭제 버튼에서 사용되는 컴포넌트로, `BaseButton`을 확장합니다:
+
+```typescript
+// shared/design/src/components/button/destructiveSolidIconButton.tsx
+import { BaseButton, type BaseButtonProps } from "./baseButton"
+
+interface DestructiveSolidIconButtonProps
+  extends BaseButtonProps,
+    DestructiveSolidIconButtonVariantProps {
+  children: React.ReactNode
+}
+
+export const DestructiveSolidIconButton = forwardRef<
+  ElementRef<typeof BaseButton>,
+  DestructiveSolidIconButtonProps
+>(({ size, className, children, ...props }, ref) => {
+  return (
+    <BaseButton
+      ref={ref}
+      className={cn(destructiveSolidIconButtonVariants({ size }), className)}
+      {...props}
+    >
+      {children}
+    </BaseButton>
+  )
+})
+```
+
+**Question 컴포넌트에서 사용:**
+```tsx
+// Question.DeleteButton에서 사용
+<DestructiveSolidIconButton
+  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onDelete?.()
+  }}
+  disabled={!canDelete}
+  aria-label={deleteLabel}
+  size="md"
+>
+  <Trash />
+</DestructiveSolidIconButton>
+```
+
+### 3. **SecondaryPlainIconButton**
+
+Question 컴포넌트의 이동 버튼들에서 사용되는 컴포넌트로, 마찬가지로 `BaseButton`을 확장합니다:
+
+```typescript
+// shared/design/src/components/button/secondaryPlainIconButton.tsx
+import { BaseButton, type BaseButtonProps } from "./baseButton"
+
+export interface SecondaryPlainIconButtonProps
+  extends BaseButtonProps,
+    VariantProps<typeof secondaryPlainIconButtonVariants> {}
+
+const SecondaryPlainIconButton = React.forwardRef<
+  ElementRef<typeof BaseButton>,
+  SecondaryPlainIconButtonProps
+>(({ className, size, ...props }, ref) => {
+  return (
+    <BaseButton
+      className={cn(secondaryPlainIconButtonVariants({ size }), className)}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+```
+
+**Question 컴포넌트에서 사용:**
+```tsx
+// Question.MoveButtons에서 사용
+<SecondaryPlainIconButton
+  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onMoveUp?.()
+  }}
+  size="md"
+  aria-label={upLabel}
+>
+  <Arrow />
+</SecondaryPlainIconButton>
+
+<SecondaryPlainIconButton
+  onClick={(e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onMoveDown?.()
+  }}
+  size="md"
+  aria-label={downLabel}
+>
+  <Arrow className="rotate-180" />
+</SecondaryPlainIconButton>
+```
+
+## 📊 컴포넌트 계층 구조
+
+```
+Question
+├── Question.DeleteButton
+│   └── DestructiveSolidIconButton
+│       └── BaseButton (Radix UI Slot 기반)
+└── Question.MoveButtons
+    ├── SecondaryPlainIconButton (위로 이동)
+    │   └── BaseButton (Radix UI Slot 기반)
+    └── SecondaryPlainIconButton (아래로 이동)
+        └── BaseButton (Radix UI Slot 기반)
+```
+
+## ♿ Question 컴포넌트 접근성 속성 상세 설명
+
+### 1. **QuestionRoot 컴포넌트의 접근성 속성**
+
+```tsx
+<div
+  role="group"
+  aria-label={accessibleName}
+  data-state={state}
+  className="..."
+  onClick={onClick}
+>
+```
+
+#### `role="group"`
+- **목적**: 질문 카드를 논리적으로 관련된 요소들의 그룹으로 정의
+- **이유**: 질문 제목, 이미지, 버튼들이 하나의 질문 단위를 구성한다는 것을 명시적으로 표현
+- **E2E 테스트**: `page.getByRole('group')` 선택자로 질문 카드를 안정적으로 찾을 수 있음
+
+#### `aria-label={accessibleName}`
+- **목적**: 각 질문 카드를 구체적으로 구분할 수 있는 접근 가능한 이름 제공
+- **값**: `title ? \`질문: ${title}\` : "질문 카드"`
+- **이유**: 
+  - 스크린 리더 사용자가 어떤 질문인지 즉시 파악 가능
+  - E2E 테스트에서 특정 질문을 정확히 선택 가능
+- **E2E 테스트**: `page.getByRole('group', { name: '질문: 첫 번째 문제입니다' })`로 특정 질문 선택
+
+#### `data-state={state}`
+- **목적**: 질문의 현재 상태를 명시적으로 표현
+- **값**: `"default" | "selected" | "error"`
+- **이유**: 
+  - Radix UI의 표준 패턴을 따라 상태 기반 스타일링 지원
+  - E2E 테스트에서 상태별 질문 필터링 가능
+  - `aria-selected`, `aria-invalid` 대신 사용하여 Radix UI와의 충돌 방지
+- **E2E 테스트**: `page.locator('[data-state="selected"]')`로 선택된 질문들만 찾기
+
+### 2. **Button 컴포넌트들의 접근성 속성**
+
+#### DestructiveSolidIconButton (삭제 버튼)
+```tsx
+<DestructiveSolidIconButton
+  aria-label={deleteLabel}
+  // ...
+>
+  <Trash />
+</DestructiveSolidIconButton>
+```
+
+#### SecondaryPlainIconButton (이동 버튼들)
+```tsx
+<SecondaryPlainIconButton
+  aria-label={upLabel}
+  // ...
+>
+  <Arrow />
+</SecondaryPlainIconButton>
+```
+
+#### `aria-label` 속성 (모든 아이콘 버튼)
+- **목적**: 텍스트가 없는 아이콘 버튼에 명확한 기능 설명 제공
+- **값**: 
+  - 삭제 버튼: `"${title} 질문 삭제"` 또는 `"질문 삭제"`
+  - 위로 이동: `"${title} 질문 위로 이동"` 또는 `"질문 위로 이동"`
+  - 아래로 이동: `"${title} 질문 아래로 이동"` 또는 `"질문 아래로 이동"`
+- **이유**:
+  - **아이콘만으로는 기능을 알 수 없음**: Trash, Arrow 아이콘만으로는 구체적인 동작을 파악하기 어려움
+  - **스크린 리더 지원**: 시각적 정보에 의존할 수 없는 사용자를 위한 필수 정보
+  - **구체적인 컨텍스트 제공**: 어떤 질문에 대한 동작인지 명확히 표시
+  - **E2E 테스트 안정성**: 버튼의 시각적 위치나 아이콘 이미지가 변경되어도 기능 기반으로 선택 가능
+- **E2E 테스트**: `page.getByRole('button', { name: '첫 번째 문제 질문 삭제' })`
+
+### 3. **Radix UI와의 호환성 고려사항**
+
+#### 제거된 속성들과 그 이유
+
+**`aria-selected` (제거됨)**
+- **문제**: HTML 표준에서 `aria-selected`는 주로 `option`, `tab`, `gridcell` 등에서 사용
+- **해결**: `data-state="selected"`로 대체하여 Radix UI 패턴과 일치
+
+**`aria-invalid` (제거됨)**
+- **문제**: Form 컨텍스트가 아닌 일반 그룹 요소에는 부적절
+- **해결**: `data-state="error"`로 대체하여 상태 표현
+
+#### 유지된 속성들과 그 이유
+
+**`aria-label` (버튼에서 유지)**
+- **이유**: Radix UI의 BaseButton이 표준 HTML `<button>` 요소를 사용하므로 안전
+- **근거**: HTML 표준에서 button 요소의 `aria-label`은 공식 지원 속성
+
+
+## 🔄 Figma 디자인 대비 리팩토링 변경사항
+
+현재 Question 컴포넌트는 원본 Figma 디자인에서 크게 리팩토링되었습니다. 주요 변경사항과 그 이유를 설명합니다.
+
+### 📐 **원본 Figma 구조**
+
+Figma의 Question 컴포넌트 세트는 다음과 같이 구성되어 있었습니다:
+
+```
+COMPONENT_SET "question"
+├── COMPONENT "state=selected, image=true"   (350×118px)
+├── COMPONENT "state=selected, image=false"  (350×118px)  
+├── COMPONENT "state=error, image=true"      (350×118px)
+├── COMPONENT "state=error, image=false"     (350×118px)
+├── COMPONENT "state=default, image=true"    (350×118px)
+└── COMPONENT "state=default, image=false"   (350×118px)
+```
+
+**Figma 구조의 특징:**
+- **고정된 배리언트**: `state` × `image` 조합으로 6개의 고정 배리언트
+- **절대 위치 기반**: 각 요소가 절대 위치로 배치 (`x`, `y` 좌표)
+- **Figma 전용 속성**: `layoutMode="NONE"`, 절대 좌표 기반 레이아웃
+
+### 🔧 **리팩토링된 현재 구조**
+
+현재 구현은 **Compound Component Pattern**을 사용한 유연한 구조로 변경되었습니다:
+
+```typescript
+// 현재 구현
+<Question state="default" title="첫 번째 질문">
+  <Question.Title>첫 번째 질문</Question.Title>
+  <Question.Image>
+    <img src="/image.jpg" alt="질문 이미지" />
+  </Question.Image>
+  <Question.DeleteButton onDelete={handleDelete} />
+  <Question.MoveButtons onMoveUp={handleMoveUp} onMoveDown={handleMoveDown} />
+</Question>
+```
+
+### 🎯 **주요 변경사항과 이유**
+
+#### 1. **Compound Component Pattern 도입**
+
+**변경 전 (Figma):**
+```
+- 6개의 고정 배리언트
+- state와 image 조합으로만 사용 가능
+- 내부 구조 변경 불가
+```
+
+**변경 후 (현재):**
+```typescript
+// 유연한 조합 가능
+<Question state="selected">
+  <Question.Title>질문 제목</Question.Title>
+  <Question.Actions>
+    <CustomButton />  // 사용자 정의 버튼 추가 가능
+  </Question.Actions>
+</Question>
+```
+
+**이유:**
+- **확장성**: 새로운 요구사항에 맞춰 유연하게 조합 가능
+- **재사용성**: 부분적으로 다른 구성이 필요한 경우 대응 가능
+- **유지보수성**: 개별 하위 컴포넌트를 독립적으로 수정 가능
+
+#### 2. **상태 관리 방식 변경**
+
+**변경 전 (Figma):**
+```
+- state=default|selected|error (고정)
+- image=true|false (고정)
+- 6개 배리언트로만 제한
+```
+
+**변경 후 (현재):**
+```typescript
+interface QuestionRootProps {
+  state: "default" | "selected" | "error"
+  title?: string      // 접근성을 위한 제목
+  onClick?: () => void // 인터랙션 지원
+  // image (boolean) 속성 삭제
+}
+```
+
+**이유:**
+- **동적 상태**: 런타임에 상태 변경 가능
+- **인터랙션**: 클릭 등 사용자 상호작용 지원
+- 합성 컴포넌트 패턴으로 충분히 처리 가능한 불필요한 속성 (image) 삭제
+
+#### 3. **이미지 처리 방식 개선**
+
+**변경 후 (현재):**
+```typescript
+// shared/design 패키지에서는 일반 img 태그 사용 (Next.js 독립적)
+<Question state="default" title="질문 제목">
+  <Question.Image>
+    <img 
+      src="/question-images/sample.jpg"
+      alt="질문 관련 이미지"
+      className="size-[78px] rounded-[7px]"
+    />
+  </Question.Image>
+</Question>
+
+// 기본 fallback 이미지
+<Question.Image>
+  <img src="/checker.svg" alt="기본 이미지" className="size-[78px] rounded-[7px]" />
+</Question.Image>
+
+// 커스텀 fallback 컴포넌트
+<Question.Image fallback={
+  <div className="flex size-[78px] items-center justify-center rounded-[7px] bg-background-tertiary">
+    <PlaceholderIcon />
+  </div>
+} />
+
+// service/app에서 Next.js Image 사용 시
+<Question state="default" title="질문 제목">
+  <Question.Image>
+    <Image 
+      src="/question-images/sample.jpg"
+      alt="질문 관련 이미지"
+      width={78}
+      height={78}
+      className="rounded-[7px]"
+      priority
+    />
+  </Question.Image>
+</Question>
+```
+
+**이유:**
+- **패키지 독립성**: shared/design은 Next.js에 의존하지 않는 순수 React 컴포넌트
+- **유연성**: 일반 img 태그와 Next.js Image 모두 주입 가능
+- **프레임워크 중립**: 다른 React 기반 프레임워크에서도 재사용 가능
+- **커스터마이징**: fallback 컴포넌트와 다양한 이미지 처리 방식 지원
+
+#### 4. **사용 예시 변경**
+
+**변경 전 (Figma):**
+```typescript
+<QuestionComponent variant="state=selected,image=true" />
+```
+
+**변경 후 (현재):**
+```typescript
+<Question state="selected" title="질문 제목" onClick={handleClick}>
+  <Question.Title>사용자 정의 제목</Question.Title>
+  <Question.Image fallback={<CustomFallback />} />
+  <Question.DeleteButton canDelete={canDelete} onDelete={onDelete} />
+</Question>
+```
+
+

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -11,7 +11,7 @@ type QuestionState = "default" | "selected" | "error"
 interface QuestionContextType {
   state: QuestionState
   onClick?: () => void
-  hasError?: boolean
+  title?: string
 }
 
 const QuestionContext = createContext<QuestionContextType | null>(null)
@@ -30,7 +30,7 @@ interface QuestionRootProps {
   onClick?: () => void
   children: React.ReactNode
   className?: string
-  hasError?: boolean
+  title?: string
 }
 
 const QuestionRoot = ({
@@ -38,7 +38,7 @@ const QuestionRoot = ({
   onClick,
   children,
   className = "",
-  hasError = false,
+  title,
 }: QuestionRootProps) => {
   const getStateClasses = () => {
     switch (state) {
@@ -51,9 +51,14 @@ const QuestionRoot = ({
     }
   }
 
+  const accessibleName = title ? `질문: ${title}` : "질문 카드"
+
   return (
-    <QuestionContext.Provider value={{ state, onClick, hasError }}>
+    <QuestionContext.Provider value={{ state, onClick, title }}>
       <div
+        role="group"
+        aria-label={accessibleName}
+        data-state={state}
         className={`relative h-[118px] w-[350px] shrink-0 cursor-pointer rounded-[10px] border-2 bg-background-primary p-5 ${getStateClasses()} ${className}`}
         onClick={onClick}
       >
@@ -69,13 +74,13 @@ interface QuestionTitleProps {
 }
 
 const QuestionTitle = ({ children, className = "" }: QuestionTitleProps) => {
-  const { state, hasError } = useQuestionContext()
+  const { state } = useQuestionContext()
 
   return (
     <h3
       className={`typography-heading-sm-medium line-clamp-1 overflow-hidden text-ellipsis pr-[157px] pt-1 text-text-primary ${className}`}
     >
-      {hasError || state === "error" ? <>❗ {children}</> : children}
+      {state === "error" ? <>❗ {children}</> : children}
     </h3>
   )
 }
@@ -120,6 +125,10 @@ const QuestionDeleteButton = ({
   canDelete = true,
   className = "",
 }: QuestionDeleteButtonProps) => {
+  const { title } = useQuestionContext()
+
+  const deleteLabel = title ? `${title} 질문 삭제` : "질문 삭제"
+
   return (
     <div className={`absolute bottom-4 left-4 ${className}`}>
       <DestructiveSolidIconButton
@@ -128,7 +137,7 @@ const QuestionDeleteButton = ({
           onDelete?.()
         }}
         disabled={!canDelete}
-        aria-label="질문 삭제"
+        aria-label={deleteLabel}
         size="md"
       >
         <Trash />
@@ -149,6 +158,11 @@ const QuestionMoveButtons = ({
   onMoveDown,
   className = "",
 }: QuestionMoveButtonsProps) => {
+  const { title } = useQuestionContext()
+
+  const upLabel = title ? `${title} 질문 위로 이동` : "질문 위로 이동"
+  const downLabel = title ? `${title} 질문 아래로 이동` : "질문 아래로 이동"
+
   return (
     <div
       className={`absolute right-4 top-5 flex flex-col items-center gap-5 ${className}`}
@@ -159,7 +173,7 @@ const QuestionMoveButtons = ({
           onMoveUp?.()
         }}
         size="md"
-        aria-label="위로 이동"
+        aria-label={upLabel}
       >
         <Arrow />
       </SecondaryPlainIconButton>
@@ -170,7 +184,7 @@ const QuestionMoveButtons = ({
           onMoveDown?.()
         }}
         size="md"
-        aria-label="아래로 이동"
+        aria-label={downLabel}
       >
         <Arrow className="rotate-180" />
       </SecondaryPlainIconButton>

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -1,7 +1,13 @@
 "use client"
 
-import type { MouseEvent } from "react"
-import { createContext, useContext } from "react"
+import { type MouseEvent } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
 
 import { Arrow, Trash } from "../../icons"
 import { DestructiveSolidIconButton, SecondaryPlainIconButton } from "../button"
@@ -11,7 +17,8 @@ type QuestionState = "default" | "selected" | "error"
 interface QuestionContextType {
   state: QuestionState
   onClick?: () => void
-  title?: string
+  accessibilityTitle?: string
+  setAccessibilityTitle: (title: string) => void
 }
 
 const QuestionContext = createContext<QuestionContextType | null>(null)
@@ -30,7 +37,6 @@ interface QuestionRootProps {
   onClick?: () => void
   children: React.ReactNode
   className?: string
-  title?: string
 }
 
 const QuestionRoot = ({
@@ -38,8 +44,12 @@ const QuestionRoot = ({
   onClick,
   children,
   className = "",
-  title,
 }: QuestionRootProps) => {
+  const [accessibilityTitle, setAccessibilityTitleState] = useState<string>("")
+
+  const setAccessibilityTitle = useCallback((title: string) => {
+    setAccessibilityTitleState(title)
+  }, [])
   const getStateClasses = () => {
     switch (state) {
       case "selected":
@@ -51,10 +61,14 @@ const QuestionRoot = ({
     }
   }
 
-  const accessibleName = title ? `질문: ${title}` : "질문 카드"
+  const accessibleName = accessibilityTitle
+    ? `질문: ${accessibilityTitle}`
+    : "질문 카드"
 
   return (
-    <QuestionContext.Provider value={{ state, onClick, title }}>
+    <QuestionContext.Provider
+      value={{ state, onClick, accessibilityTitle, setAccessibilityTitle }}
+    >
       <div
         role="group"
         aria-label={accessibleName}
@@ -74,7 +88,13 @@ interface QuestionTitleProps {
 }
 
 const QuestionTitle = ({ children, className = "" }: QuestionTitleProps) => {
-  const { state } = useQuestionContext()
+  const { state, setAccessibilityTitle } = useQuestionContext()
+
+  useEffect(() => {
+    if (typeof children === "string") {
+      setAccessibilityTitle(children)
+    }
+  }, [children, setAccessibilityTitle])
 
   return (
     <h3
@@ -125,9 +145,11 @@ const QuestionDeleteButton = ({
   canDelete = true,
   className = "",
 }: QuestionDeleteButtonProps) => {
-  const { title } = useQuestionContext()
+  const { accessibilityTitle } = useQuestionContext()
 
-  const deleteLabel = title ? `${title} 질문 삭제` : "질문 삭제"
+  const deleteLabel = accessibilityTitle
+    ? `${accessibilityTitle} 질문 삭제`
+    : "질문 삭제"
 
   return (
     <div className={`absolute bottom-4 left-4 ${className}`}>
@@ -158,10 +180,14 @@ const QuestionMoveButtons = ({
   onMoveDown,
   className = "",
 }: QuestionMoveButtonsProps) => {
-  const { title } = useQuestionContext()
+  const { accessibilityTitle } = useQuestionContext()
 
-  const upLabel = title ? `${title} 질문 위로 이동` : "질문 위로 이동"
-  const downLabel = title ? `${title} 질문 아래로 이동` : "질문 아래로 이동"
+  const upLabel = accessibilityTitle
+    ? `${accessibilityTitle} 질문 위로 이동`
+    : "질문 위로 이동"
+  const downLabel = accessibilityTitle
+    ? `${accessibilityTitle} 질문 아래로 이동`
+    : "질문 아래로 이동"
 
   return (
     <div

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -1,13 +1,7 @@
 "use client"
 
 import { type MouseEvent } from "react"
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react"
+import { createContext, useContext } from "react"
 
 import { Arrow, Trash } from "../../icons"
 import { DestructiveSolidIconButton, SecondaryPlainIconButton } from "../button"
@@ -17,8 +11,7 @@ type QuestionState = "default" | "selected" | "error"
 interface QuestionContextType {
   state: QuestionState
   onClick?: () => void
-  accessibilityTitle?: string
-  setAccessibilityTitle: (title: string) => void
+  index?: number
 }
 
 const QuestionContext = createContext<QuestionContextType | null>(null)
@@ -37,6 +30,7 @@ interface QuestionRootProps {
   onClick?: () => void
   children: React.ReactNode
   className?: string
+  index?: number
 }
 
 const QuestionRoot = ({
@@ -44,12 +38,8 @@ const QuestionRoot = ({
   onClick,
   children,
   className = "",
+  index,
 }: QuestionRootProps) => {
-  const [accessibilityTitle, setAccessibilityTitleState] = useState<string>("")
-
-  const setAccessibilityTitle = useCallback((title: string) => {
-    setAccessibilityTitleState(title)
-  }, [])
   const getStateClasses = () => {
     switch (state) {
       case "selected":
@@ -61,14 +51,10 @@ const QuestionRoot = ({
     }
   }
 
-  const accessibleName = accessibilityTitle
-    ? `질문: ${accessibilityTitle}`
-    : "질문 카드"
+  const accessibleName = index ? `${index}번째 문제` : "질문 카드"
 
   return (
-    <QuestionContext.Provider
-      value={{ state, onClick, accessibilityTitle, setAccessibilityTitle }}
-    >
+    <QuestionContext.Provider value={{ state, onClick, index }}>
       <div
         role="group"
         aria-label={accessibleName}
@@ -88,13 +74,7 @@ interface QuestionTitleProps {
 }
 
 const QuestionTitle = ({ children, className = "" }: QuestionTitleProps) => {
-  const { state, setAccessibilityTitle } = useQuestionContext()
-
-  useEffect(() => {
-    if (typeof children === "string") {
-      setAccessibilityTitle(children)
-    }
-  }, [children, setAccessibilityTitle])
+  const { state } = useQuestionContext()
 
   return (
     <h3
@@ -145,11 +125,9 @@ const QuestionDeleteButton = ({
   canDelete = true,
   className = "",
 }: QuestionDeleteButtonProps) => {
-  const { accessibilityTitle } = useQuestionContext()
+  const { index } = useQuestionContext()
 
-  const deleteLabel = accessibilityTitle
-    ? `${accessibilityTitle} 질문 삭제`
-    : "질문 삭제"
+  const deleteLabel = index ? `${index}번째 문제 삭제` : "문제 삭제"
 
   return (
     <div className={`absolute bottom-4 left-4 ${className}`}>
@@ -180,14 +158,10 @@ const QuestionMoveButtons = ({
   onMoveDown,
   className = "",
 }: QuestionMoveButtonsProps) => {
-  const { accessibilityTitle } = useQuestionContext()
+  const { index } = useQuestionContext()
 
-  const upLabel = accessibilityTitle
-    ? `${accessibilityTitle} 질문 위로 이동`
-    : "질문 위로 이동"
-  const downLabel = accessibilityTitle
-    ? `${accessibilityTitle} 질문 아래로 이동`
-    : "질문 아래로 이동"
+  const upLabel = index ? `${index}번째 문제 위로 이동` : "문제 위로 이동"
+  const downLabel = index ? `${index}번째 문제 아래로 이동` : "문제 아래로 이동"
 
   return (
     <div

--- a/shared/design/src/stories/question.stories.tsx
+++ b/shared/design/src/stories/question.stories.tsx
@@ -13,6 +13,11 @@ const meta = {
     state: {
       control: { type: "select" },
       options: ["default", "selected", "error"],
+      description: "문제 상태",
+    },
+    index: {
+      control: { type: "number", min: 1, max: 10 },
+      description: "문제 순서 (1부터 시작)",
     },
     onClick: { action: "clicked" },
   },
@@ -24,10 +29,11 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     state: "default",
+    index: 1,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>질문 내용이 여기에 표시됩니다</Question.Title>
       <Question.Image />
       <Question.DeleteButton />
@@ -39,10 +45,11 @@ export const Default: Story = {
 export const Selected: Story = {
   args: {
     state: "selected",
+    index: 2,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>
         선택된 질문입니다선택된 질문입니다선택된 질문입니다선택된
         질문입니다선택된 질문입니다선택된 질문입니다선택된 질문입니다선택된
@@ -59,10 +66,11 @@ export const Selected: Story = {
 export const ErrorState: Story = {
   args: {
     state: "error",
+    index: 3,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>
         질문은 입력되었지만 답안이 입력되지 않은 에러 상태입니다
       </Question.Title>
@@ -76,10 +84,11 @@ export const ErrorState: Story = {
 export const SelectedWithError: Story = {
   args: {
     state: "selected",
+    index: 4,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>선택된 상태이지만 에러가 있는 질문입니다</Question.Title>
       <Question.Image />
       <Question.DeleteButton />
@@ -91,10 +100,11 @@ export const SelectedWithError: Story = {
 export const WithImage: Story = {
   args: {
     state: "default",
+    index: 5,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>이미지가 있는 질문입니다</Question.Title>
       <Question.Image>
         <img
@@ -112,10 +122,11 @@ export const WithImage: Story = {
 export const CustomActions: Story = {
   args: {
     state: "default",
+    index: 6,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question state={args.state} onClick={args.onClick}>
+    <Question state={args.state} index={args.index} onClick={args.onClick}>
       <Question.Title>커스텀 액션이 있는 질문</Question.Title>
       <Question.Image />
       <Question.Actions>

--- a/shared/design/src/stories/question.stories.tsx
+++ b/shared/design/src/stories/question.stories.tsx
@@ -14,9 +14,6 @@ const meta = {
       control: { type: "select" },
       options: ["default", "selected", "error"],
     },
-    hasError: {
-      control: { type: "boolean" },
-    },
     onClick: { action: "clicked" },
   },
 } satisfies Meta<typeof Question>
@@ -79,15 +76,10 @@ export const ErrorState: Story = {
 export const SelectedWithError: Story = {
   args: {
     state: "selected",
-    hasError: true,
     children: "placeholder" as React.ReactNode,
   },
   render: (args) => (
-    <Question
-      state={args.state}
-      hasError={args.hasError}
-      onClick={args.onClick}
-    >
+    <Question state={args.state} onClick={args.onClick}>
       <Question.Title>선택된 상태이지만 에러가 있는 질문입니다</Question.Title>
       <Question.Image />
       <Question.DeleteButton />

--- a/shared/design/src/stories/question.stories.tsx
+++ b/shared/design/src/stories/question.stories.tsx
@@ -2,137 +2,334 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Question } from "../components/question"
 
+interface StoryArgs {
+  state: "default" | "selected" | "error"
+  index?: number
+  onClick?: () => void
+  title?: string
+  image?: string
+  canDelete?: boolean
+  onDelete?: () => void
+  onMoveUp?: () => void
+  onMoveDown?: () => void
+  customActions?: React.ReactNode
+}
+
 const meta = {
   title: "Components/Question",
   component: Question,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: `
+## 🎯 Question 컴포넌트 - 게임 질문 카드
+
+게임 생성 시 사용되는 질문 카드 컴포넌트입니다. **Compound Component Pattern**을 사용하여 유연한 구성이 가능합니다.
+
+### 🏗️ 주요 특징
+
+- **Radix UI 기반**: BaseButton(Slot 기반)을 사용한 안정적인 접근성
+- **순서 기반 접근성**: \`index\` prop으로 "n번째 문제" 자동 라벨링
+- **동적 상태 관리**: 실시간 상태 변경 및 에러 처리 지원
+- **유연한 구성**: Title, Image, Actions를 자유롭게 조합 가능
+
+### 📱 언제 사용하나요?
+
+- **게임 생성 화면**: 질문 목록 표시 및 편집
+- **질문 관리**: 순서 변경, 삭제, 상태 관리
+- **에러 처리**: 필수 입력 누락 시 시각적 피드백
+
+### ⚠️ 주의사항
+
+- \`index\` prop은 1부터 시작 (배열 index + 1)
+- 마지막 질문은 \`canDelete={false}\`로 삭제 방지 필요
+- 이미지는 78×78px 권장, shared/design에서는 일반 img 태그 사용
+
+### 🔗 관련 컴포넌트
+
+- \`DestructiveSolidIconButton\`: 삭제 버튼
+- \`SecondaryPlainIconButton\`: 이동 버튼들
+- \`QuestionList\`: 여러 질문을 관리하는 상위 컴포넌트
+
+### 🔄 Figma 디자인 대비 주요 변경사항
+
+#### 1. **Compound Component Pattern 도입**
+**변경 전 (Figma)**: 6개 고정 배리언트 (\`state × image\` 조합)  
+**변경 후 (현재)**: 유연한 조합 가능한 합성 컴포넌트
+
+\`\`\`typescript
+// Figma: 고정된 배리언트
+<QuestionComponent variant="state=selected,image=true" />
+
+// 현재: 자유로운 구성
+<Question state="selected" index={1}>
+  <Question.Title>커스텀 제목</Question.Title>
+  <Question.Image>
+    <CustomImage />
+  </Question.Image>
+  <Question.Actions>
+    <CustomButton />  // 사용자 정의 액션 추가 가능
+  </Question.Actions>
+</Question>
+\`\`\`
+
+#### 2. **순서 기반 접근성 시스템**
+**추가된 기능**: \`index\` prop으로 자동 접근성 라벨 생성
+- Question 카드: \`aria-label="n번째 문제"\`
+- 삭제 버튼: \`aria-label="n번째 문제 삭제"\`
+- 이동 버튼: \`aria-label="n번째 문제 위로/아래로 이동"\`
+
+#### 3. **이미지 처리 방식 개선**
+**변경 전**: \`image={true/false}\` 고정 속성  
+**변경 후**: 유연한 이미지 주입 시스템
+
+\`\`\`typescript
+// 일반 img 태그 (shared/design)
+<Question.Image>
+  <img src="/image.jpg" alt="설명" className="size-[78px]" />
+</Question.Image>
+
+// Next.js Image 주입 가능 (service/app)
+<Question.Image>
+  <Image src="/image.jpg" width={78} height={78} />
+</Question.Image>
+
+// 커스텀 fallback 지원
+<Question.Image fallback={<CustomPlaceholder />} />
+\`\`\`
+
+#### 4. **동적 상태 관리**
+**추가된 기능**: 런타임 상태 변경 및 인터랙션 지원
+- \`onClick\` 이벤트로 편집 모드 전환
+- \`canDelete\` prop으로 동적 삭제 제한
+- 실시간 에러 상태 반영 (\`state="error"\`)
+        `,
+      },
+    },
   },
   tags: ["autodocs"],
   argTypes: {
     state: {
       control: { type: "select" },
       options: ["default", "selected", "error"],
-      description: "문제 상태",
+      description:
+        "**문제 상태**\n- `default`: 기본 상태\n- `selected`: 현재 편집 중\n- `error`: 입력 누락/검증 실패",
     },
     index: {
       control: { type: "number", min: 1, max: 10 },
-      description: "문제 순서 (1부터 시작)",
+      description:
+        '**문제 순서** (1부터 시작)\n- 접근성 라벨 자동 생성: "n번째 문제"\n- 버튼 라벨에도 반영: "n번째 문제 삭제"',
     },
-    onClick: { action: "clicked" },
+    onClick: {
+      action: "clicked",
+      description:
+        "**클릭 이벤트**\n- 질문 선택 시 호출\n- 편집 모드 전환 등에 활용",
+    },
   },
 } satisfies Meta<typeof Question>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<StoryArgs>
 
-export const Default: Story = {
-  args: {
-    state: "default",
-    index: 1,
-    children: "placeholder" as React.ReactNode,
-  },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>질문 내용이 여기에 표시됩니다</Question.Title>
-      <Question.Image />
-      <Question.DeleteButton />
-      <Question.MoveButtons />
-    </Question>
-  ),
-}
-
-export const Selected: Story = {
-  args: {
-    state: "selected",
-    index: 2,
-    children: "placeholder" as React.ReactNode,
-  },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>
-        선택된 질문입니다선택된 질문입니다선택된 질문입니다선택된
-        질문입니다선택된 질문입니다선택된 질문입니다선택된 질문입니다선택된
-        질문입니다선택된 질문입니다선택된 질문입니다선택된 질문입니다선택된
-        질문입니다선택된 질문입니다선택된 질문입니다선택된 질문입니다
-      </Question.Title>
-      <Question.Image />
-      <Question.DeleteButton />
-      <Question.MoveButtons />
-    </Question>
-  ),
-}
-
-export const ErrorState: Story = {
-  args: {
-    state: "error",
-    index: 3,
-    children: "placeholder" as React.ReactNode,
-  },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>
-        질문은 입력되었지만 답안이 입력되지 않은 에러 상태입니다
-      </Question.Title>
-      <Question.Image />
-      <Question.DeleteButton />
-      <Question.MoveButtons />
-    </Question>
-  ),
-}
-
-export const SelectedWithError: Story = {
-  args: {
-    state: "selected",
-    index: 4,
-    children: "placeholder" as React.ReactNode,
-  },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>선택된 상태이지만 에러가 있는 질문입니다</Question.Title>
-      <Question.Image />
-      <Question.DeleteButton />
-      <Question.MoveButtons />
-    </Question>
-  ),
-}
-
-export const WithImage: Story = {
-  args: {
-    state: "default",
-    index: 5,
-    children: "placeholder" as React.ReactNode,
-  },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>이미지가 있는 질문입니다</Question.Title>
+const Template = (args: StoryArgs) => (
+  <Question state={args.state} index={args.index} onClick={args.onClick}>
+    <Question.Title>{args.title}</Question.Title>
+    {args.image ? (
       <Question.Image>
         <img
-          src="/exampleThumbnail.jpg"
-          alt="질문 이미지"
+          src={args.image}
+          alt="문제 이미지"
           className="size-[78px] rounded-[7px] object-cover"
         />
       </Question.Image>
-      <Question.DeleteButton />
-      <Question.MoveButtons />
-    </Question>
+    ) : (
+      <Question.Image />
+    )}
+    {args.customActions ? (
+      <Question.Actions>{args.customActions}</Question.Actions>
+    ) : (
+      <>
+        <Question.DeleteButton
+          canDelete={args.canDelete}
+          onDelete={args.onDelete}
+        />
+        <Question.MoveButtons
+          onMoveUp={args.onMoveUp}
+          onMoveDown={args.onMoveDown}
+        />
+      </>
+    )}
+  </Question>
+)
+
+export const BasicTextQuestion: Story = {
+  args: {
+    state: "default",
+    index: 1,
+    title: "사용자의 취미는 무엇인가요?",
+    canDelete: true,
+  },
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**가장 기본적인 질문 카드**입니다. 이미지 없이 텍스트만으로 구성됩니다.",
+      },
+    },
+  },
+}
+
+export const CurrentlyEditing: Story = {
+  args: {
+    state: "selected",
+    index: 2,
+    title: "가장 좋아하는 음식을 설명해 주세요",
+    canDelete: true,
+  },
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**현재 편집 중인 상태**입니다. 사용자가 질문을 선택했을 때 나타나는 시각적 피드백을 보여줍니다.",
+      },
+    },
+  },
+}
+
+export const ValidationError: Story = {
+  args: {
+    state: "error",
+    index: 3,
+    title: "문제를 입력해주세요",
+    canDelete: true,
+  },
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**검증 실패 상태**입니다. 필수 입력이 누락되거나 유효하지 않은 질문일 때 표시됩니다. 제목 앞에 ❗ 아이콘이 자동으로 추가됩니다.",
+      },
+    },
+  },
+}
+
+export const QuestionWithImage: Story = {
+  args: {
+    state: "default",
+    index: 4,
+    title: "이 이미지에서 무엇을 보시나요?",
+    image: "/exampleThumbnail.jpg",
+    canDelete: true,
+  },
+  render: Template,
+}
+
+export const LastRequiredQuestion: Story = {
+  args: {
+    state: "default",
+    index: 1,
+    title: "최소 하나의 문제은 필요합니다",
+    canDelete: false,
+  },
+  render: Template,
+}
+
+export const GameCreationScenario: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**실제 게임 생성 시나리오**입니다. 여러 질문이 함께 있을 때의 모습과 다양한 상태를 한 번에 확인할 수 있습니다.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6 p-4">
+      <h3 className="mb-4 text-lg font-semibold">게임 문제 목록</h3>
+
+      <Question state="selected" index={1}>
+        <Question.Title>편집중인 문제</Question.Title>
+        <Question.Image />
+        <Question.DeleteButton canDelete={true} />
+        <Question.MoveButtons />
+      </Question>
+
+      <Question state="default" index={2}>
+        <Question.Title>작성된 문제</Question.Title>
+        <Question.Image>
+          <img
+            src="/exampleThumbnail.jpg"
+            alt="문제 이미지"
+            className="size-[78px] rounded-[7px] object-cover"
+          />
+        </Question.Image>
+        <Question.DeleteButton canDelete={true} />
+        <Question.MoveButtons />
+      </Question>
+
+      <Question state="error" index={3}>
+        <Question.Title>문제를 입력해주세요</Question.Title>
+        <Question.Image />
+        <Question.DeleteButton canDelete={true} />
+        <Question.MoveButtons />
+      </Question>
+    </div>
   ),
+}
+
+export const WithClickAction: Story = {
+  args: {
+    state: "default",
+    index: 1,
+    title: "클릭해서 편집 모드로 전환",
+    canDelete: true,
+    onClick: () => alert("문제가 선택되었습니다!"),
+  },
+  render: Template,
+}
+
+export const WithMoveActions: Story = {
+  args: {
+    state: "default",
+    index: 2,
+    title: "위/아래 이동 버튼 테스트",
+    canDelete: true,
+    onMoveUp: () => alert("위로 이동!"),
+    onMoveDown: () => alert("아래로 이동!"),
+  },
+  render: Template,
 }
 
 export const CustomActions: Story = {
   args: {
     state: "default",
-    index: 6,
-    children: "placeholder" as React.ReactNode,
+    index: 1,
+    title: "커스텀 액션 버튼들",
+    customActions: (
+      <div className="absolute bottom-4 right-4 flex gap-2">
+        <button className="rounded bg-blue-500 px-3 py-1 text-sm text-white">
+          복사
+        </button>
+        <button className="rounded bg-green-500 px-3 py-1 text-sm text-white">
+          저장
+        </button>
+      </div>
+    ),
   },
-  render: (args) => (
-    <Question state={args.state} index={args.index} onClick={args.onClick}>
-      <Question.Title>커스텀 액션이 있는 질문</Question.Title>
-      <Question.Image />
-      <Question.Actions>
-        <Question.DeleteButton canDelete={false} />
-        <Question.MoveButtons />
-      </Question.Actions>
-    </Question>
-  ),
+  render: Template,
+}
+
+export const LongTextQuestion: Story = {
+  args: {
+    state: "default",
+    index: 1,
+    title:
+      "이것은 매우 긴 질문 제목입니다. 텍스트가 너무 길어서 한 줄을 넘어가는 경우에 어떻게 처리되는지 확인하기 위한 예시입니다.",
+    canDelete: true,
+  },
+  render: Template,
 }


### PR DESCRIPTION
## 📝 설명

question 컴포넌트에 필요한 aria-label을 붙이고 관련 내용을 문서화했습니다.

## 🛠️ 주요 변경 사항

- 접근성 관련 태그 작성 및 이전 태그 정리 7b10cb15046fa5f1985bfdc98b8d29b8e5828985 89293d7c2c9b0a2083c902446d44a863c006b677 4dd251ec171480b3863f015b2c0776e95f037d6f
- 관련 내용 문서화 5f68ddb717235c2c949ac674a62edbec9809b0d1

## 리뷰 시 고려해야 할 사항

문서에 피그마와의 다른점 / 컴포넌트 구성 / 컴포넌트 사용 예시 / 접근성 가이드를 작성해 두었습니다. 문서는 pr에 포함되어 있어서 리뷰하실 때 읽어보시면 될 것 같습니다 (README에 종합적으로 작성해 두었고, storybook 문서에 간소화해서 작성 완료했습니다)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Question 상태를 기본/선택/오류의 3단계(state)로 통합 및 Question 사용 시 index 전달(index={index+1})로 상태/레이블 관리.
  - hasError prop 제거 및 public API가 index?: number로 변경되어 인덱스 기반 접근성 라벨 적용(그룹 role/aria-label, 아이콘 버튼 라벨 포함).
  - QuestionList 항목의 개별 ARIA 레이블·role·data-testid 제거 및 항목 래퍼 간소화.
- Documentation
  - Question 컴포넌트 README 추가(구조, 접근성, 사용 예시, 테스트 가이드, 이미지 전략).
- Tests / Stories
  - Storybook: hasError 제거, index arg 도입, Template 기반 재구성 및 여러 신규/갱신된 스토리 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->