### PR TITLE
textField 컴포넌트 업데이트 및 spacing 토큰 등록

### DIFF
--- a/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/teamInputForm.tsx
@@ -1,7 +1,11 @@
 "use client"
 
-import { PrimaryBoxButton } from "@ject-5-fe/design/components/button"
-import * as InputComponents from "@ject-5-fe/design/components/input"
+import {
+  DestructiveSolidIconButton,
+  PrimaryBoxButton,
+} from "@ject-5-fe/design/components/button"
+import * as TextField from "@ject-5-fe/design/components/textField"
+import { Trash } from "@ject-5-fe/design/icons"
 import { useMemo } from "react"
 import { v4 as uuidv4 } from "uuid"
 import { useShallow } from "zustand/react/shallow"
@@ -28,13 +32,11 @@ export function TeamInputForm() {
   const teamErrors = useMemo(() => getTeamErrors(teams), [teams])
 
   return (
-    <InputComponents.Root
+    <form
       className="flex w-full flex-col gap-6"
       onSubmit={(e) => {
         e.preventDefault()
-        if (teams.length >= MAX_TEAMS) {
-          return
-        }
+        if (teams.length >= MAX_TEAMS) return
 
         addTeam({
           id: uuidv4(),
@@ -44,36 +46,39 @@ export function TeamInputForm() {
         })
       }}
     >
-      {teams.map((team, index) => (
-        <InputComponents.Field
-          name={`team-${team.id}-${index}`}
-          type="reset"
-          state={teamErrors[team.id] ? "error" : "default"}
-          key={team.id}
-        >
-          <InputComponents.Control
-            value={team.name}
-            onChange={(value) => {
-              if (value.length > MAX_TEAM_NAME_LENGTH) {
-                return
-              }
-              updateTeamName(team.id, value.trim())
-            }}
-            onReset={() => {
-              if (teams.length > MIN_TEAMS) {
-                removeTeam(team.id)
-              }
-            }}
-            maxLength={MAX_TEAM_NAME_LENGTH}
-            max={MAX_TEAM_NAME_LENGTH}
-          />
-          {teamErrors[team.id] && (
-            <InputComponents.ErrorText>
-              {teamErrors[team.id]}
-            </InputComponents.ErrorText>
-          )}
-        </InputComponents.Field>
-      ))}
+      {teams.map((team, index) => {
+        const name = `team-${team.id}-${index}`
+        const state = teamErrors[team.id] ? "error" : "default"
+        return (
+          <TextField.Root name={name} state={state} key={team.id}>
+            <TextField.InputWrapper>
+              <TextField.Input
+                value={team.name}
+                onChange={(e) => {
+                  const value = e.target.value
+                  if (value.length > MAX_TEAM_NAME_LENGTH) return
+                  updateTeamName(team.id, value.trim())
+                }}
+                maxLength={MAX_TEAM_NAME_LENGTH}
+              />
+              <DestructiveSolidIconButton
+                type="button"
+                aria-label="clear input"
+                onClick={() => {
+                  if (teams.length > MIN_TEAMS) {
+                    removeTeam(team.id)
+                  }
+                }}
+              >
+                <Trash />
+              </DestructiveSolidIconButton>
+            </TextField.InputWrapper>
+            {teamErrors[team.id] && (
+              <TextField.ErrorText>{teamErrors[team.id]}</TextField.ErrorText>
+            )}
+          </TextField.Root>
+        )
+      })}
       <PrimaryBoxButton
         size="xl"
         _style="solid"
@@ -81,6 +86,6 @@ export function TeamInputForm() {
       >
         참가자 및 팀 추가하기
       </PrimaryBoxButton>
-    </InputComponents.Root>
+    </form>
   )
 }

--- a/service/app/src/entities/game/ui/components/createGameNavigation.tsx
+++ b/service/app/src/entities/game/ui/components/createGameNavigation.tsx
@@ -1,10 +1,7 @@
 "use client"
 
-import {
-  PrimaryBoxButton,
-} from "@shared/design/src/components/button"
-import { Control, Field, Root } from "@shared/design/src/components/input"
-import { ErrorText } from "@shared/design/src/components/input"
+import { PrimaryBoxButton } from "@shared/design/src/components/button"
+import * as TextField from "@shared/design/src/components/textField"
 import { ThemeToggle } from "@shared/design/src/components/themeToggle"
 import { useTheme } from "next-themes"
 import { useEffect, useState } from "react"
@@ -21,6 +18,8 @@ export function CreateGameNavigation() {
   useEffect(() => {
     setMounted(true)
   }, [])
+
+  console.log(state)
 
   const handleGameNameChange = (value: string) => {
     actions.setGameName(value)
@@ -43,25 +42,23 @@ export function CreateGameNavigation() {
       className={`flex h-[110px] w-full items-center justify-between bg-background-tertiary px-10`}
     >
       <div className="flex w-[420px] items-center gap-2.5 bg-background-tertiary px-10">
-        <Root>
-          <Field
-            type="noIcon"
-            state={selectors.gameNameError ? "error" : "default"}
-            name="gameTitle"
-            className="bg-background-interactive-input-primary"
-          >
-            <Control
+        <TextField.Root
+          name="gameTitle"
+          state={selectors.gameNameError ? "error" : "default"}
+        >
+          <TextField.InputWrapper className="bg-background-interactive-input-primary">
+            <TextField.Input
               placeholder="게임 이름 입력"
               value={state.gameName}
-              onChange={handleGameNameChange}
+              onChange={(e) => handleGameNameChange(e.target.value)}
               onFocus={handleGameNameFocus}
               onBlur={handleGameNameBlur}
             />
-            {selectors.gameNameError && (
-              <ErrorText>{selectors.gameNameError}</ErrorText>
-            )}
-          </Field>
-        </Root>
+          </TextField.InputWrapper>
+          {selectors.gameNameError && (
+            <TextField.ErrorText>{selectors.gameNameError}</TextField.ErrorText>
+          )}
+        </TextField.Root>
       </div>
 
       <div className="flex w-[420px] items-center justify-end gap-4 px-10">

--- a/service/app/src/entities/game/ui/components/questionInputForm.tsx
+++ b/service/app/src/entities/game/ui/components/questionInputForm.tsx
@@ -1,12 +1,6 @@
 "use client"
 
-import {
-  Control,
-  ErrorText,
-  Field,
-  Label,
-  Root,
-} from "@shared/design/src/components/input"
+import * as TextField from "@ject-5-fe/design/components/textField"
 
 import { useGameCreationContext } from "../../model/state/create/gameCreationContext"
 import {
@@ -35,39 +29,41 @@ export function QuestionInputForm() {
 
   return (
     <div className="flex w-[420px] flex-col gap-[54px]">
-      <Root>
-        <Field
-          state={questionError ? "error" : "default"}
-          type="labelOn"
-          name="question"
-          className="w-full"
-        >
-          <Label>질문*</Label>
-          <Control
+      <TextField.Root
+        name="question"
+        state={questionError ? "error" : "default"}
+        className="w-full"
+      >
+        <TextField.Label>질문*</TextField.Label>
+        <TextField.InputWrapper>
+          <TextField.Input
             placeholder="질문 입력"
             value={selectedQuestion?.text || ""}
-            onChange={handleQuestionChange}
+            onChange={(e) => handleQuestionChange(e.target.value)}
           />
-          {questionError && <ErrorText>{questionError}</ErrorText>}
-        </Field>
-      </Root>
+        </TextField.InputWrapper>
+        {questionError && (
+          <TextField.ErrorText>{questionError}</TextField.ErrorText>
+        )}
+      </TextField.Root>
 
-      <Root>
-        <Field
-          state={answerError ? "error" : "default"}
-          type="labelOn"
-          name="answer"
-          className="w-full"
-        >
-          <Label>답안*</Label>
-          <Control
+      <TextField.Root
+        name="answer"
+        state={answerError ? "error" : "default"}
+        className="w-full"
+      >
+        <TextField.Label>답안*</TextField.Label>
+        <TextField.InputWrapper>
+          <TextField.Input
             placeholder="답안 입력"
             value={selectedQuestion?.answer || ""}
-            onChange={handleAnswerChange}
+            onChange={(e) => handleAnswerChange(e.target.value)}
           />
-          {answerError && <ErrorText>{answerError}</ErrorText>}
-        </Field>
-      </Root>
+        </TextField.InputWrapper>
+        {answerError && (
+          <TextField.ErrorText>{answerError}</TextField.ErrorText>
+        )}
+      </TextField.Root>
     </div>
   )
 }

--- a/shared/design/src/components/textField/index.tsx
+++ b/shared/design/src/components/textField/index.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import { cva } from "class-variance-authority"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react"
+
+import { cn } from "../../utils/cn"
+
+type TextFieldVariant = {
+  state?: "default" | "error"
+}
+
+const baseVariants = "flex w-full flex-col items-start space-y-5"
+
+const labelVariants = "typography-heading-sm-semibold text-text-primary"
+
+const inputWrapperVariants = cva(
+  "flex w-full shrink-0 items-center gap-2 rounded-[8px] border-2 bg-background-interactive-input-primary p-[20px]",
+  {
+    variants: {
+      state: {
+        default:
+          "border-border-interactive-input-default focus-within:border-border-interactive-input-focused",
+        error:
+          "border-border-interactive-input-error focus-within:border-border-interactive-input-error",
+      },
+    },
+    defaultVariants: {
+      state: "default" as const,
+    },
+  },
+)
+
+const inputVariants =
+  "typography-heading-sm-medium flex-1 gap-2 bg-transparent text-text-interactive-input-filled placeholder:text-text-interactive-input-placeholder focus:outline-none"
+
+const errorTextVariants =
+  "typography-body-sm-medium -mt-2 text-text-interactive-input-error"
+
+type TextFieldContextValue = {
+  name?: string
+  state: TextFieldVariant["state"]
+  inputId: string
+  errorId?: string
+  setErrorId: (id: string | undefined) => void
+}
+
+const TextFieldContext = createContext<TextFieldContextValue | undefined>(
+  undefined,
+)
+
+const useTextFieldContext = () => {
+  const ctx = useContext(TextFieldContext)
+  if (!ctx) {
+    throw new Error(
+      "TextField.* components must be used within <TextField.Root>",
+    )
+  }
+  return ctx
+}
+
+export const Root = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div"> &
+    TextFieldVariant & {
+      name: string
+      inputId?: string
+      children: ReactNode
+    }
+>(
+  (
+    {
+      className,
+      name,
+      state = "default",
+      inputId: inputIdProp,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const reactId = useId()
+    const inputId = useMemo(
+      () => inputIdProp ?? (name ? `${name}-input` : `text-field-${reactId}`),
+      [inputIdProp, name, reactId],
+    )
+
+    const [errorId, setErrorId] = useState<string | undefined>(undefined)
+
+    const contextValue = useMemo<TextFieldContextValue>(
+      () => ({ name, state, inputId, errorId, setErrorId }),
+      [name, state, inputId, errorId],
+    )
+
+    return (
+      <TextFieldContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          className={cn(baseVariants, className)}
+          role="group"
+          {...props}
+        >
+          {children}
+        </div>
+      </TextFieldContext.Provider>
+    )
+  },
+)
+Root.displayName = "TextField.Root"
+
+export const Label = forwardRef<
+  HTMLLabelElement,
+  ComponentPropsWithoutRef<"label">
+>(({ className, children, htmlFor, ...props }, ref) => {
+  const { inputId } = useTextFieldContext()
+  return (
+    <label
+      ref={ref}
+      className={cn(labelVariants, className)}
+      htmlFor={htmlFor ?? inputId}
+      {...props}
+    >
+      {children}
+    </label>
+  )
+})
+
+Label.displayName = "TextField.Label"
+
+export const InputWrapper = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, children, ...props }, ref) => {
+  const { state } = useTextFieldContext()
+
+  return (
+    <div
+      ref={ref}
+      className={cn(inputWrapperVariants({ state }), className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+})
+InputWrapper.displayName = "TextField.InputWrapper"
+
+type InputProps = ComponentPropsWithoutRef<"input">
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      id,
+      name,
+      type = "text",
+      "aria-invalid": ariaInvalid,
+      "aria-describedby": ariaDescribedBy,
+      ...props
+    },
+    ref,
+  ) => {
+    const { state, name: ctxName, inputId, errorId } = useTextFieldContext()
+
+    const mergedDescribedBy = useMemo(() => {
+      const parts = [ariaDescribedBy]
+      if (state === "error" && errorId) parts.push(errorId)
+      return parts.filter(Boolean).join(" ") || undefined
+    }, [ariaDescribedBy, state, errorId])
+
+    const mergedAriaInvalid =
+      ariaInvalid ?? (state === "error" ? true : undefined)
+
+    return (
+      <input
+        ref={ref}
+        className={cn(inputVariants, className)}
+        id={id ?? inputId}
+        name={name ?? ctxName}
+        type={type}
+        aria-invalid={mergedAriaInvalid}
+        aria-describedby={mergedDescribedBy}
+        {...props}
+      />
+    )
+  },
+)
+Input.displayName = "TextField.Input"
+
+export const LeftAddon = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ className, children, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+})
+LeftAddon.displayName = "TextField.LeftAddon"
+
+export const ErrorText = forwardRef<
+  HTMLParagraphElement,
+  ComponentPropsWithoutRef<"p"> & { id?: string }
+>(({ className, id, children, ...props }, ref) => {
+  const { inputId, setErrorId } = useTextFieldContext()
+  const resolvedId = id ?? `${inputId}-error`
+
+  useEffect(() => {
+    setErrorId(resolvedId)
+    return () => setErrorId(undefined)
+  }, [resolvedId, setErrorId])
+
+  return (
+    <p
+      ref={ref}
+      id={resolvedId}
+      role="alert"
+      aria-live="polite"
+      aria-atomic="true"
+      className={cn(errorTextVariants, className)}
+      {...props}
+    >
+      {children}
+    </p>
+  )
+})
+ErrorText.displayName = "TextField.ErrorText"

--- a/shared/design/src/plugin/index.ts
+++ b/shared/design/src/plugin/index.ts
@@ -47,8 +47,8 @@ export default plugin(
   },
   {
     theme: {
-      spacing: spacingTheme,
       extend: {
+        spacing: spacingTheme,
         borderRadius: radiusTheme,
         colors: colorTheme,
         typography: typographyTheme,

--- a/shared/design/src/plugin/index.ts
+++ b/shared/design/src/plugin/index.ts
@@ -2,10 +2,13 @@ import plugin from "tailwindcss/plugin"
 import type { CSSRuleObject } from "tailwindcss/types/config"
 
 import { generateColorTokens } from "../tokens/color"
+import { generateRadiusTokens } from "../tokens/radius"
+import { generateSpacingTokens } from "../tokens/spacing"
 import {
   fontWeightTokens,
   generateTypographyTokens,
 } from "../tokens/typography"
+import { generateUnitTokens } from "../tokens/unit"
 
 const {
   base: colorBase,
@@ -13,6 +16,9 @@ const {
   theme: colorTheme,
 } = generateColorTokens()
 const { theme: typographyTheme } = generateTypographyTokens()
+const { theme: spacingTheme } = generateSpacingTokens()
+const { theme: radiusTheme } = generateRadiusTokens()
+const { cssVars: unitCssVars } = generateUnitTokens()
 
 export default plugin(
   ({ addBase, addComponents, theme }) => {
@@ -20,6 +26,7 @@ export default plugin(
       ":root": {
         ...fontWeightTokens,
         ...colorBase,
+        ...unitCssVars,
       },
       ".dark": {
         ...colorDark,
@@ -40,7 +47,9 @@ export default plugin(
   },
   {
     theme: {
+      spacing: spacingTheme,
       extend: {
+        borderRadius: radiusTheme,
         colors: colorTheme,
         typography: typographyTheme,
         fontWeight: fontWeightTokens,

--- a/shared/design/src/stories/textField.stories.tsx
+++ b/shared/design/src/stories/textField.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { expect, userEvent, within } from "storybook/test"
+
+import * as TextField from "../components/textField"
+
+const meta: Meta<typeof TextField.Root> = {
+  title: "Components/TextField",
+  component: TextField.Root,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+- Root (\`<div>\`): 단순 컨테이너로, 폼 제출이 필요하면 외부 \`<form>\`을 사용해야 합니다
+  - name(required): 필수 prop으로, 하위 태그들의 attribute의 prefix로 사용됩니다
+  - state: default | error : 기본값은 default로, error로 변경 시 input과 errorText에 스타일이 적용됩니다
+
+- Label (\`<label>\`):
+  - html label 태그입니다
+  - for(htmlFor): [name]-input
+  - htmlFor 속성과 input 태그의 id가 자동으로 연결됩니다
+
+- Input (\`<input>\`):
+  - type: text
+  - aria-invalid: state가 'error'일 때 true로 설정됩니다
+  - aria-describedby: ErrorText 컴포넌트가 있을 경우, 해당 태그의 id([name]-input-error)와 연결됩니다
+
+- ErrorText (\`<p>\`):
+  - id: "[name]-input-error"
+  - role="alert" aria-live="polite" aria-atomic="true"
+  - 마운트 시 Field 컨텍스트에 id를 등록/해제하여 Input의 aria-describedby에 반영됩니다
+
+
+`,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    state: {
+      control: { type: "select" },
+      options: ["default", "error"],
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    name: "example",
+    state: "default",
+  },
+  render: (args) => {
+    const [val, setVal] = useState("")
+    return (
+      <TextField.Root {...args}>
+        <TextField.Label>이름</TextField.Label>
+        <TextField.InputWrapper>
+          <TextField.Input
+            placeholder="이름을 입력하세요"
+            value={val}
+            onChange={(e) => setVal(e.target.value)}
+          />
+        </TextField.InputWrapper>
+      </TextField.Root>
+    )
+  },
+}
+
+export const Error: Story = {
+  args: {
+    name: "example-error",
+    state: "error",
+  },
+  render: (args) => {
+    const [val, setVal] = useState("")
+    return (
+      <TextField.Root {...args}>
+        <TextField.Label>이메일</TextField.Label>
+        <TextField.InputWrapper>
+          <TextField.Input
+            placeholder="이메일을 입력하세요"
+            value={val}
+            onChange={(e) => setVal(e.target.value)}
+          />
+        </TextField.InputWrapper>
+        <TextField.ErrorText>올바른 이메일을 입력해주세요</TextField.ErrorText>
+      </TextField.Root>
+    )
+  },
+}
+
+export const NoLabel: Story = {
+  args: {
+    name: "no-label",
+    state: "default",
+  },
+  render: (args) => {
+    const [val, setVal] = useState("")
+    return (
+      <TextField.Root {...args}>
+        <TextField.InputWrapper>
+          <TextField.Input
+            placeholder="라벨 없이 입력"
+            value={val}
+            onChange={(e) => setVal(e.target.value)}
+          />
+        </TextField.InputWrapper>
+      </TextField.Root>
+    )
+  },
+}
+
+export const WithValidation: Story = {
+  args: {
+    name: "email-validation",
+  },
+  render: (args) => {
+    const [val, setVal] = useState("")
+    const isError = val.length === 0 || !/^\S+@\S+\.\S+$/.test(val)
+
+    return (
+      <TextField.Root {...args} state={isError ? "error" : "default"}>
+        <TextField.Label>유효성 검증</TextField.Label>
+        <TextField.InputWrapper>
+          <TextField.Input
+            placeholder="이메일을 입력하세요"
+            value={val}
+            onChange={(e) => setVal(e.target.value)}
+          />
+        </TextField.InputWrapper>
+        {isError && (
+          <TextField.ErrorText>
+            올바른 이메일을 입력해주세요
+          </TextField.ErrorText>
+        )}
+      </TextField.Root>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByLabelText("유효성 검증")
+
+    await step(
+      "유효성 검사에 실패하면 에러텍스트가 렌더링되고 aria-invalid / aria-describedby가 설정됨",
+      async () => {
+        const alertEl = canvas.getByRole("alert")
+        expect(alertEl).toBeInTheDocument()
+        expect(alertEl).toHaveAttribute("id", "email-validation-input-error")
+        expect(input).toHaveAttribute("aria-invalid", "true")
+        expect(input).toHaveAttribute(
+          "aria-describedby",
+          "email-validation-input-error",
+        )
+      },
+    )
+
+    await step(
+      "유효성 검사에 통과하면 에러텍스트가 제거되고 aria-invalid / aria-describedby가 제거됨",
+      async () => {
+        await userEvent.clear(input)
+        await userEvent.type(input, "test@example.com")
+        expect(canvas.queryByRole("alert")).toBeNull()
+        expect(input).not.toHaveAttribute("aria-invalid")
+        expect(input).not.toHaveAttribute("aria-describedby")
+      },
+    )
+  },
+}

--- a/shared/design/src/tokens/color.ts
+++ b/shared/design/src/tokens/color.ts
@@ -18,23 +18,31 @@ if (!primitiveColorCollection || !semanticColorCollection) {
   throw new Error("Collection not found")
 }
 
-const primitiveColor = primitiveColorCollection.modes[0].variables.reduce(
-  (acc, variable) => {
-    if (typeof variable.value === "object") {
-      throw new Error("primitive color is not string")
-    }
-    const name = `--${convertName(variable.name)}`
-    acc[name] = variable.value as string
-    return acc
-  },
-  {} as Record<string, string>,
-)
+const primitiveColor = primitiveColorCollection.modes[0].variables
+  // color 타입만 처리
+  .filter((variable) => variable.type === "color")
+  .reduce(
+    (acc, variable) => {
+      if (typeof variable.value === "object") {
+        throw new Error("primitive color is not string")
+      }
+      const name = `--${convertName(variable.name)}`
+      acc[name] = variable.value as string
+      return acc
+    },
+    {} as Record<string, string>,
+  )
 
 const semanticColorLight = semanticColorCollection.modes
   .filter((mode) => mode.name === "light")[0]
-  .variables.reduce(
+  .variables.filter((variable) => variable.type === "color")
+  .reduce(
     (acc, variable) => {
-      if (typeof variable.value !== "object" || !("name" in variable.value)) {
+      if (
+        variable.type !== "color" ||
+        typeof variable.value !== "object" ||
+        !("name" in variable.value)
+      ) {
         throw new Error("semantic color alias value should have name property")
       }
       const key = `--${convertName(variable.name)}`
@@ -48,9 +56,14 @@ const semanticColorLight = semanticColorCollection.modes
 
 const semanticColorDark = semanticColorCollection.modes
   .filter((mode) => mode.name === "dark")[0]
-  .variables.reduce(
+  .variables.filter((variable) => variable.type === "color") //컬러 타입만 처리
+  .reduce(
     (acc, variable) => {
-      if (typeof variable.value !== "object" || !("name" in variable.value)) {
+      if (
+        variable.type !== "color" ||
+        typeof variable.value !== "object" ||
+        !("name" in variable.value)
+      ) {
         throw new Error("semantic color alias value should have name property")
       }
       const key = `--${convertName(variable.name)}`

--- a/shared/design/src/tokens/radius.ts
+++ b/shared/design/src/tokens/radius.ts
@@ -1,0 +1,57 @@
+import { convertNameToVar } from "./utils"
+import variables from "./variables.json"
+
+const primitive = variables.collections.find((c) => c.name === "primitive")
+const semantic = variables.collections.find((c) => c.name === "semantic")
+
+if (!primitive || !semantic) {
+  throw new Error("Collection not found")
+}
+
+export const generateRadiusTokens = () => {
+  const theme: { [key: string]: string } = {}
+  const vars = semantic.modes[0].variables
+  for (const v of vars) {
+    if (
+      typeof v.name === "string" &&
+      v.name.startsWith("border radius/") &&
+      v.type === "number" &&
+      v.isAlias === true &&
+      typeof v.value === "object" &&
+      v.value !== null &&
+      "name" in v.value
+    ) {
+      const key = v.name.split("border-radius-")[1]
+      const ref = (v.value as { name: string }).name
+      if (typeof key === "string") {
+        theme[key] = ref.endsWith("/0") ? "0" : convertNameToVar(ref)
+      }
+    }
+  }
+  return { theme }
+}
+
+export const generateRadiusCssVars = () => {
+  const vars: { [key: string]: string } = {}
+  const sema = semantic.modes[0].variables
+  for (const v of sema) {
+    if (
+      typeof v.name === "string" &&
+      v.name.startsWith("border radius/") &&
+      v.type === "number" &&
+      v.isAlias === true &&
+      typeof v.value === "object" &&
+      v.value !== null &&
+      "name" in v.value
+    ) {
+      const key = v.name.split("border-radius-")[1]
+      const ref = (v.value as { name: string }).name
+      if (typeof key === "string") {
+        vars[`--radius-${key}`] = ref.endsWith("/0")
+          ? "0"
+          : convertNameToVar(ref)
+      }
+    }
+  }
+  return vars
+}

--- a/shared/design/src/tokens/spacing.ts
+++ b/shared/design/src/tokens/spacing.ts
@@ -1,0 +1,6 @@
+import { generateUnitTokens } from "./unit"
+
+export const generateSpacingTokens = () => {
+  const { theme } = generateUnitTokens()
+  return { theme }
+}

--- a/shared/design/src/tokens/unit.ts
+++ b/shared/design/src/tokens/unit.ts
@@ -1,0 +1,24 @@
+import { convertNameToVar } from "./utils"
+import variables from "./variables.json"
+
+const primitive = variables.collections.find((c) => c.name === "primitive")
+
+export const generateUnitTokens = () => {
+  const list = primitive?.modes?.[0]?.variables ?? []
+  const cssVars: Record<string, string> = {}
+  const theme: Record<string, string> = {}
+  for (const v of list) {
+    if (
+      typeof v.name === "string" &&
+      v.name.startsWith("unit/") &&
+      v.type === "number" &&
+      typeof v.value === "number"
+    ) {
+      const key = String(v.name.split("/")[1])
+      const px = v.value
+      cssVars[`--unit-${key}`] = key === "0" ? "0" : String(px) + "px"
+      theme[key] = key === "0" ? "0" : convertNameToVar(v.name)
+    }
+  }
+  return { cssVars, theme }
+}

--- a/shared/design/src/tokens/variables.json
+++ b/shared/design/src/tokens/variables.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.4",
+  "version": "1.0.5",
   "metadata": {},
   "collections": [
     {
@@ -367,6 +367,498 @@
               "type": "color",
               "isAlias": false,
               "value": "#460809"
+            },
+            {
+              "name": "unit/0",
+              "type": "number",
+              "isAlias": false,
+              "value": 0
+            },
+            {
+              "name": "unit/1",
+              "type": "number",
+              "isAlias": false,
+              "value": 1
+            },
+            {
+              "name": "unit/2",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "unit/4",
+              "type": "number",
+              "isAlias": false,
+              "value": 4
+            },
+            {
+              "name": "unit/8",
+              "type": "number",
+              "isAlias": false,
+              "value": 8
+            },
+            {
+              "name": "unit/12",
+              "type": "number",
+              "isAlias": false,
+              "value": 12
+            },
+            {
+              "name": "unit/16",
+              "type": "number",
+              "isAlias": false,
+              "value": 16
+            },
+            {
+              "name": "unit/20",
+              "type": "number",
+              "isAlias": false,
+              "value": 20
+            },
+            {
+              "name": "unit/24",
+              "type": "number",
+              "isAlias": false,
+              "value": 24
+            },
+            {
+              "name": "unit/28",
+              "type": "number",
+              "isAlias": false,
+              "value": 28
+            },
+            {
+              "name": "unit/32",
+              "type": "number",
+              "isAlias": false,
+              "value": 32
+            },
+            {
+              "name": "unit/36",
+              "type": "number",
+              "isAlias": false,
+              "value": 36
+            },
+            {
+              "name": "unit/40",
+              "type": "number",
+              "isAlias": false,
+              "value": 40
+            },
+            {
+              "name": "unit/44",
+              "type": "number",
+              "isAlias": false,
+              "value": 44
+            },
+            {
+              "name": "unit/48",
+              "type": "number",
+              "isAlias": false,
+              "value": 48
+            },
+            {
+              "name": "unit/52",
+              "type": "number",
+              "isAlias": false,
+              "value": 52
+            },
+            {
+              "name": "unit/56",
+              "type": "number",
+              "isAlias": false,
+              "value": 56
+            },
+            {
+              "name": "unit/60",
+              "type": "number",
+              "isAlias": false,
+              "value": 60
+            },
+            {
+              "name": "unit/64",
+              "type": "number",
+              "isAlias": false,
+              "value": 64
+            },
+            {
+              "name": "unit/68",
+              "type": "number",
+              "isAlias": false,
+              "value": 68
+            },
+            {
+              "name": "unit/72",
+              "type": "number",
+              "isAlias": false,
+              "value": 72
+            },
+            {
+              "name": "unit/76",
+              "type": "number",
+              "isAlias": false,
+              "value": 76
+            },
+            {
+              "name": "unit/80",
+              "type": "number",
+              "isAlias": false,
+              "value": 80
+            },
+            {
+              "name": "unit/84",
+              "type": "number",
+              "isAlias": false,
+              "value": 84
+            },
+            {
+              "name": "unit/88",
+              "type": "number",
+              "isAlias": false,
+              "value": 88
+            },
+            {
+              "name": "unit/92",
+              "type": "number",
+              "isAlias": false,
+              "value": 92
+            },
+            {
+              "name": "unit/96",
+              "type": "number",
+              "isAlias": false,
+              "value": 96
+            },
+            {
+              "name": "unit/100",
+              "type": "number",
+              "isAlias": false,
+              "value": 100
+            },
+            {
+              "name": "unit/104",
+              "type": "number",
+              "isAlias": false,
+              "value": 104
+            },
+            {
+              "name": "unit/108",
+              "type": "number",
+              "isAlias": false,
+              "value": 108
+            },
+            {
+              "name": "unit/112",
+              "type": "number",
+              "isAlias": false,
+              "value": 112
+            },
+            {
+              "name": "unit/116",
+              "type": "number",
+              "isAlias": false,
+              "value": 116
+            },
+            {
+              "name": "unit/120",
+              "type": "number",
+              "isAlias": false,
+              "value": 120
+            },
+            {
+              "name": "unit/124",
+              "type": "number",
+              "isAlias": false,
+              "value": 124
+            },
+            {
+              "name": "unit/128",
+              "type": "number",
+              "isAlias": false,
+              "value": 128
+            },
+            {
+              "name": "unit/132",
+              "type": "number",
+              "isAlias": false,
+              "value": 132
+            },
+            {
+              "name": "unit/136",
+              "type": "number",
+              "isAlias": false,
+              "value": 136
+            },
+            {
+              "name": "unit/140",
+              "type": "number",
+              "isAlias": false,
+              "value": 140
+            },
+            {
+              "name": "unit/144",
+              "type": "number",
+              "isAlias": false,
+              "value": 144
+            },
+            {
+              "name": "unit/148",
+              "type": "number",
+              "isAlias": false,
+              "value": 148
+            },
+            {
+              "name": "unit/152",
+              "type": "number",
+              "isAlias": false,
+              "value": 152
+            },
+            {
+              "name": "unit/156",
+              "type": "number",
+              "isAlias": false,
+              "value": 156
+            },
+            {
+              "name": "unit/160",
+              "type": "number",
+              "isAlias": false,
+              "value": 160
+            },
+            {
+              "name": "unit/164",
+              "type": "number",
+              "isAlias": false,
+              "value": 164
+            },
+            {
+              "name": "unit/168",
+              "type": "number",
+              "isAlias": false,
+              "value": 168
+            },
+            {
+              "name": "unit/172",
+              "type": "number",
+              "isAlias": false,
+              "value": 172
+            },
+            {
+              "name": "unit/176",
+              "type": "number",
+              "isAlias": false,
+              "value": 176
+            },
+            {
+              "name": "unit/180",
+              "type": "number",
+              "isAlias": false,
+              "value": 180
+            },
+            {
+              "name": "unit/184",
+              "type": "number",
+              "isAlias": false,
+              "value": 184
+            },
+            {
+              "name": "unit/188",
+              "type": "number",
+              "isAlias": false,
+              "value": 188
+            },
+            {
+              "name": "unit/192",
+              "type": "number",
+              "isAlias": false,
+              "value": 192
+            },
+            {
+              "name": "unit/196",
+              "type": "number",
+              "isAlias": false,
+              "value": 196
+            },
+            {
+              "name": "unit/200",
+              "type": "number",
+              "isAlias": false,
+              "value": 200
+            },
+            {
+              "name": "unit/204",
+              "type": "number",
+              "isAlias": false,
+              "value": 204
+            },
+            {
+              "name": "unit/208",
+              "type": "number",
+              "isAlias": false,
+              "value": 208
+            },
+            {
+              "name": "unit/212",
+              "type": "number",
+              "isAlias": false,
+              "value": 212
+            },
+            {
+              "name": "unit/216",
+              "type": "number",
+              "isAlias": false,
+              "value": 216
+            },
+            {
+              "name": "unit/220",
+              "type": "number",
+              "isAlias": false,
+              "value": 220
+            },
+            {
+              "name": "unit/224",
+              "type": "number",
+              "isAlias": false,
+              "value": 224
+            },
+            {
+              "name": "unit/228",
+              "type": "number",
+              "isAlias": false,
+              "value": 228
+            },
+            {
+              "name": "unit/232",
+              "type": "number",
+              "isAlias": false,
+              "value": 232
+            },
+            {
+              "name": "unit/236",
+              "type": "number",
+              "isAlias": false,
+              "value": 236
+            },
+            {
+              "name": "unit/240",
+              "type": "number",
+              "isAlias": false,
+              "value": 240
+            },
+            {
+              "name": "unit/244",
+              "type": "number",
+              "isAlias": false,
+              "value": 244
+            },
+            {
+              "name": "unit/248",
+              "type": "number",
+              "isAlias": false,
+              "value": 248
+            },
+            {
+              "name": "unit/252",
+              "type": "number",
+              "isAlias": false,
+              "value": 252
+            },
+            {
+              "name": "unit/256",
+              "type": "number",
+              "isAlias": false,
+              "value": 256
+            },
+            {
+              "name": "unit/260",
+              "type": "number",
+              "isAlias": false,
+              "value": 260
+            },
+            {
+              "name": "unit/264",
+              "type": "number",
+              "isAlias": false,
+              "value": 264
+            },
+            {
+              "name": "unit/268",
+              "type": "number",
+              "isAlias": false,
+              "value": 268
+            },
+            {
+              "name": "unit/272",
+              "type": "number",
+              "isAlias": false,
+              "value": 272
+            },
+            {
+              "name": "unit/276",
+              "type": "number",
+              "isAlias": false,
+              "value": 276
+            },
+            {
+              "name": "unit/280",
+              "type": "number",
+              "isAlias": false,
+              "value": 280
+            },
+            {
+              "name": "unit/284",
+              "type": "number",
+              "isAlias": false,
+              "value": 284
+            },
+            {
+              "name": "unit/288",
+              "type": "number",
+              "isAlias": false,
+              "value": 288
+            },
+            {
+              "name": "unit/292",
+              "type": "number",
+              "isAlias": false,
+              "value": 292
+            },
+            {
+              "name": "unit/296",
+              "type": "number",
+              "isAlias": false,
+              "value": 296
+            },
+            {
+              "name": "unit/300",
+              "type": "number",
+              "isAlias": false,
+              "value": 300
+            },
+            {
+              "name": "unit/304",
+              "type": "number",
+              "isAlias": false,
+              "value": 304
+            },
+            {
+              "name": "unit/308",
+              "type": "number",
+              "isAlias": false,
+              "value": 308
+            },
+            {
+              "name": "unit/312",
+              "type": "number",
+              "isAlias": false,
+              "value": 312
+            },
+            {
+              "name": "unit/999",
+              "type": "number",
+              "isAlias": false,
+              "value": 999
             }
           ]
         }
@@ -505,7 +997,7 @@
               }
             },
             {
-              "name": "color/icon/secondary",
+              "name": "color/icon/interactive/secondary",
               "type": "color",
               "isAlias": true,
               "value": {
@@ -514,7 +1006,7 @@
               }
             },
             {
-              "name": "color/icon/interactive/secondary",
+              "name": "color/icon/secondary",
               "type": "color",
               "isAlias": true,
               "value": {
@@ -890,6 +1382,915 @@
                 "collection": "primitive",
                 "name": "neutral/white"
               }
+            },
+            {
+              "name": "spacing/spacing-0",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/0"
+              }
+            },
+            {
+              "name": "spacing/spacing-1",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/1"
+              }
+            },
+            {
+              "name": "spacing/spacing-2",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/2"
+              }
+            },
+            {
+              "name": "spacing/spacing-4",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/4"
+              }
+            },
+            {
+              "name": "spacing/spacing-8",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/8"
+              }
+            },
+            {
+              "name": "spacing/spacing-12",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/12"
+              }
+            },
+            {
+              "name": "spacing/spacing-16",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/16"
+              }
+            },
+            {
+              "name": "spacing/spacing-20",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/20"
+              }
+            },
+            {
+              "name": "spacing/spacing-24",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/24"
+              }
+            },
+            {
+              "name": "spacing/spacing-28",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/28"
+              }
+            },
+            {
+              "name": "spacing/spacing-32",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/32"
+              }
+            },
+            {
+              "name": "spacing/spacing-36",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/36"
+              }
+            },
+            {
+              "name": "spacing/spacing-40",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/40"
+              }
+            },
+            {
+              "name": "spacing/spacing-44",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/44"
+              }
+            },
+            {
+              "name": "spacing/spacing-48",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/48"
+              }
+            },
+            {
+              "name": "spacing/spacing-52",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/52"
+              }
+            },
+            {
+              "name": "spacing/spacing-56",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/56"
+              }
+            },
+            {
+              "name": "spacing/spacing-60",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/60"
+              }
+            },
+            {
+              "name": "spacing/spacing-64",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/64"
+              }
+            },
+            {
+              "name": "spacing/spacing-68",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/68"
+              }
+            },
+            {
+              "name": "spacing/spacing-72",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/72"
+              }
+            },
+            {
+              "name": "spacing/spacing-76",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/76"
+              }
+            },
+            {
+              "name": "spacing/spacing-80",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/80"
+              }
+            },
+            {
+              "name": "spacing/spacing-84",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/84"
+              }
+            },
+            {
+              "name": "spacing/spacing-88",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/88"
+              }
+            },
+            {
+              "name": "spacing/spacing-92",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/92"
+              }
+            },
+            {
+              "name": "spacing/spacing-96",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/96"
+              }
+            },
+            {
+              "name": "spacing/spacing-100",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/100"
+              }
+            },
+            {
+              "name": "spacing/spacing-104",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/104"
+              }
+            },
+            {
+              "name": "spacing/spacing-108",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/108"
+              }
+            },
+            {
+              "name": "spacing/spacing-112",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/112"
+              }
+            },
+            {
+              "name": "spacing/spacing-116",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/116"
+              }
+            },
+            {
+              "name": "spacing/spacing-120",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/120"
+              }
+            },
+            {
+              "name": "spacing/spacing-124",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/124"
+              }
+            },
+            {
+              "name": "spacing/spacing-128",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/128"
+              }
+            },
+            {
+              "name": "spacing/spacing-132",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/132"
+              }
+            },
+            {
+              "name": "spacing/spacing-136",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/136"
+              }
+            },
+            {
+              "name": "spacing/spacing-140",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/140"
+              }
+            },
+            {
+              "name": "spacing/spacing-144",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/144"
+              }
+            },
+            {
+              "name": "spacing/spacing-148",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/148"
+              }
+            },
+            {
+              "name": "spacing/spacing-152",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/152"
+              }
+            },
+            {
+              "name": "spacing/spacing-156",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/156"
+              }
+            },
+            {
+              "name": "spacing/spacing-160",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/160"
+              }
+            },
+            {
+              "name": "spacing/spacing-164",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/164"
+              }
+            },
+            {
+              "name": "spacing/spacing-168",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/168"
+              }
+            },
+            {
+              "name": "spacing/spacing-172",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/172"
+              }
+            },
+            {
+              "name": "spacing/spacing-176",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/176"
+              }
+            },
+            {
+              "name": "spacing/spacing-180",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/180"
+              }
+            },
+            {
+              "name": "spacing/spacing-184",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/184"
+              }
+            },
+            {
+              "name": "spacing/spacing-188",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/188"
+              }
+            },
+            {
+              "name": "spacing/spacing-192",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/192"
+              }
+            },
+            {
+              "name": "spacing/spacing-196",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/196"
+              }
+            },
+            {
+              "name": "spacing/spacing-200",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/200"
+              }
+            },
+            {
+              "name": "spacing/spacing-204",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/204"
+              }
+            },
+            {
+              "name": "spacing/spacing-208",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/208"
+              }
+            },
+            {
+              "name": "spacing/spacing-212",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/212"
+              }
+            },
+            {
+              "name": "spacing/spacing-216",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/216"
+              }
+            },
+            {
+              "name": "spacing/spacing-220",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/220"
+              }
+            },
+            {
+              "name": "spacing/spacing-224",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/224"
+              }
+            },
+            {
+              "name": "spacing/spacing-228",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/228"
+              }
+            },
+            {
+              "name": "spacing/spacing-232",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/232"
+              }
+            },
+            {
+              "name": "spacing/spacing-236",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/236"
+              }
+            },
+            {
+              "name": "spacing/spacing-240",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/240"
+              }
+            },
+            {
+              "name": "spacing/spacing-244",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/244"
+              }
+            },
+            {
+              "name": "spacing/spacing-248",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/248"
+              }
+            },
+            {
+              "name": "spacing/spacing-252",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/252"
+              }
+            },
+            {
+              "name": "spacing/spacing-256",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/256"
+              }
+            },
+            {
+              "name": "spacing/spacing-260",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/260"
+              }
+            },
+            {
+              "name": "spacing/spacing-264",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/264"
+              }
+            },
+            {
+              "name": "spacing/spacing-268",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/268"
+              }
+            },
+            {
+              "name": "spacing/spacing-272",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/272"
+              }
+            },
+            {
+              "name": "spacing/spacing-276",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/276"
+              }
+            },
+            {
+              "name": "spacing/spacing-280",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/280"
+              }
+            },
+            {
+              "name": "spacing/spacing-284",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/284"
+              }
+            },
+            {
+              "name": "spacing/spacing-288",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/288"
+              }
+            },
+            {
+              "name": "spacing/spacing-292",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/292"
+              }
+            },
+            {
+              "name": "spacing/spacing-296",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/296"
+              }
+            },
+            {
+              "name": "spacing/spacing-300",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/300"
+              }
+            },
+            {
+              "name": "spacing/spacing-304",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/304"
+              }
+            },
+            {
+              "name": "spacing/spacing-308",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/308"
+              }
+            },
+            {
+              "name": "spacing/spacing-312",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/312"
+              }
+            },
+            {
+              "name": "border radius/border-radius-0",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/0"
+              }
+            },
+            {
+              "name": "border radius/border-radius-1",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/1"
+              }
+            },
+            {
+              "name": "border radius/border-radius-2",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/2"
+              }
+            },
+            {
+              "name": "border radius/border-radius-4",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/4"
+              }
+            },
+            {
+              "name": "border radius/border-radius-8",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/8"
+              }
+            },
+            {
+              "name": "border radius/border-radius-12",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/12"
+              }
+            },
+            {
+              "name": "border radius/border-radius-16",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/16"
+              }
+            },
+            {
+              "name": "border radius/border-radius-20",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/20"
+              }
+            },
+            {
+              "name": "border radius/border-radius-24",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/24"
+              }
+            },
+            {
+              "name": "border radius/border-radius-28",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/28"
+              }
+            },
+            {
+              "name": "border radius/border-radius-32",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/32"
+              }
+            },
+            {
+              "name": "border radius/border-radius-36",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/36"
+              }
+            },
+            {
+              "name": "border radius/border-radius-40",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/40"
+              }
+            },
+            {
+              "name": "border radius/border-radius-44",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/44"
+              }
+            },
+            {
+              "name": "border radius/border-radius-48",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/48"
+              }
+            },
+            {
+              "name": "border radius/border-radius-52",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/52"
+              }
+            },
+            {
+              "name": "border radius/border-radius-56",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/56"
+              }
+            },
+            {
+              "name": "border radius/border-radius-60",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/60"
+              }
+            },
+            {
+              "name": "border radius/border-radius-64",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/64"
+              }
+            },
+            {
+              "name": "border radius/border-radius-999",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/999"
+              }
             }
           ]
         },
@@ -1023,7 +2424,7 @@
               }
             },
             {
-              "name": "color/icon/secondary",
+              "name": "color/icon/interactive/secondary",
               "type": "color",
               "isAlias": true,
               "value": {
@@ -1032,7 +2433,7 @@
               }
             },
             {
-              "name": "color/icon/interactive/secondary",
+              "name": "color/icon/secondary",
               "type": "color",
               "isAlias": true,
               "value": {
@@ -1408,6 +2809,915 @@
                 "collection": "primitive",
                 "name": "gray/600"
               }
+            },
+            {
+              "name": "spacing/spacing-0",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/0"
+              }
+            },
+            {
+              "name": "spacing/spacing-1",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/1"
+              }
+            },
+            {
+              "name": "spacing/spacing-2",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/2"
+              }
+            },
+            {
+              "name": "spacing/spacing-4",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/4"
+              }
+            },
+            {
+              "name": "spacing/spacing-8",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/8"
+              }
+            },
+            {
+              "name": "spacing/spacing-12",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/12"
+              }
+            },
+            {
+              "name": "spacing/spacing-16",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/16"
+              }
+            },
+            {
+              "name": "spacing/spacing-20",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/20"
+              }
+            },
+            {
+              "name": "spacing/spacing-24",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/24"
+              }
+            },
+            {
+              "name": "spacing/spacing-28",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/28"
+              }
+            },
+            {
+              "name": "spacing/spacing-32",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/32"
+              }
+            },
+            {
+              "name": "spacing/spacing-36",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/36"
+              }
+            },
+            {
+              "name": "spacing/spacing-40",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/40"
+              }
+            },
+            {
+              "name": "spacing/spacing-44",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/44"
+              }
+            },
+            {
+              "name": "spacing/spacing-48",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/48"
+              }
+            },
+            {
+              "name": "spacing/spacing-52",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/52"
+              }
+            },
+            {
+              "name": "spacing/spacing-56",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/56"
+              }
+            },
+            {
+              "name": "spacing/spacing-60",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/60"
+              }
+            },
+            {
+              "name": "spacing/spacing-64",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/64"
+              }
+            },
+            {
+              "name": "spacing/spacing-68",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/68"
+              }
+            },
+            {
+              "name": "spacing/spacing-72",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/72"
+              }
+            },
+            {
+              "name": "spacing/spacing-76",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/76"
+              }
+            },
+            {
+              "name": "spacing/spacing-80",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/80"
+              }
+            },
+            {
+              "name": "spacing/spacing-84",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/84"
+              }
+            },
+            {
+              "name": "spacing/spacing-88",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/88"
+              }
+            },
+            {
+              "name": "spacing/spacing-92",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/92"
+              }
+            },
+            {
+              "name": "spacing/spacing-96",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/96"
+              }
+            },
+            {
+              "name": "spacing/spacing-100",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/100"
+              }
+            },
+            {
+              "name": "spacing/spacing-104",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/104"
+              }
+            },
+            {
+              "name": "spacing/spacing-108",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/108"
+              }
+            },
+            {
+              "name": "spacing/spacing-112",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/112"
+              }
+            },
+            {
+              "name": "spacing/spacing-116",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/116"
+              }
+            },
+            {
+              "name": "spacing/spacing-120",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/120"
+              }
+            },
+            {
+              "name": "spacing/spacing-124",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/124"
+              }
+            },
+            {
+              "name": "spacing/spacing-128",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/128"
+              }
+            },
+            {
+              "name": "spacing/spacing-132",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/132"
+              }
+            },
+            {
+              "name": "spacing/spacing-136",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/136"
+              }
+            },
+            {
+              "name": "spacing/spacing-140",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/140"
+              }
+            },
+            {
+              "name": "spacing/spacing-144",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/144"
+              }
+            },
+            {
+              "name": "spacing/spacing-148",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/148"
+              }
+            },
+            {
+              "name": "spacing/spacing-152",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/152"
+              }
+            },
+            {
+              "name": "spacing/spacing-156",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/156"
+              }
+            },
+            {
+              "name": "spacing/spacing-160",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/160"
+              }
+            },
+            {
+              "name": "spacing/spacing-164",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/164"
+              }
+            },
+            {
+              "name": "spacing/spacing-168",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/168"
+              }
+            },
+            {
+              "name": "spacing/spacing-172",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/172"
+              }
+            },
+            {
+              "name": "spacing/spacing-176",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/176"
+              }
+            },
+            {
+              "name": "spacing/spacing-180",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/180"
+              }
+            },
+            {
+              "name": "spacing/spacing-184",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/184"
+              }
+            },
+            {
+              "name": "spacing/spacing-188",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/188"
+              }
+            },
+            {
+              "name": "spacing/spacing-192",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/192"
+              }
+            },
+            {
+              "name": "spacing/spacing-196",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/196"
+              }
+            },
+            {
+              "name": "spacing/spacing-200",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/200"
+              }
+            },
+            {
+              "name": "spacing/spacing-204",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/204"
+              }
+            },
+            {
+              "name": "spacing/spacing-208",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/208"
+              }
+            },
+            {
+              "name": "spacing/spacing-212",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/212"
+              }
+            },
+            {
+              "name": "spacing/spacing-216",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/216"
+              }
+            },
+            {
+              "name": "spacing/spacing-220",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/220"
+              }
+            },
+            {
+              "name": "spacing/spacing-224",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/224"
+              }
+            },
+            {
+              "name": "spacing/spacing-228",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/228"
+              }
+            },
+            {
+              "name": "spacing/spacing-232",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/232"
+              }
+            },
+            {
+              "name": "spacing/spacing-236",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/236"
+              }
+            },
+            {
+              "name": "spacing/spacing-240",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/240"
+              }
+            },
+            {
+              "name": "spacing/spacing-244",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/244"
+              }
+            },
+            {
+              "name": "spacing/spacing-248",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/248"
+              }
+            },
+            {
+              "name": "spacing/spacing-252",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/252"
+              }
+            },
+            {
+              "name": "spacing/spacing-256",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/256"
+              }
+            },
+            {
+              "name": "spacing/spacing-260",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/260"
+              }
+            },
+            {
+              "name": "spacing/spacing-264",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/264"
+              }
+            },
+            {
+              "name": "spacing/spacing-268",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/268"
+              }
+            },
+            {
+              "name": "spacing/spacing-272",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/272"
+              }
+            },
+            {
+              "name": "spacing/spacing-276",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/276"
+              }
+            },
+            {
+              "name": "spacing/spacing-280",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/280"
+              }
+            },
+            {
+              "name": "spacing/spacing-284",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/284"
+              }
+            },
+            {
+              "name": "spacing/spacing-288",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/288"
+              }
+            },
+            {
+              "name": "spacing/spacing-292",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/292"
+              }
+            },
+            {
+              "name": "spacing/spacing-296",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/296"
+              }
+            },
+            {
+              "name": "spacing/spacing-300",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/300"
+              }
+            },
+            {
+              "name": "spacing/spacing-304",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/304"
+              }
+            },
+            {
+              "name": "spacing/spacing-308",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/308"
+              }
+            },
+            {
+              "name": "spacing/spacing-312",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/312"
+              }
+            },
+            {
+              "name": "border radius/border-radius-0",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/0"
+              }
+            },
+            {
+              "name": "border radius/border-radius-1",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/1"
+              }
+            },
+            {
+              "name": "border radius/border-radius-2",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/2"
+              }
+            },
+            {
+              "name": "border radius/border-radius-4",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/4"
+              }
+            },
+            {
+              "name": "border radius/border-radius-8",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/8"
+              }
+            },
+            {
+              "name": "border radius/border-radius-12",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/12"
+              }
+            },
+            {
+              "name": "border radius/border-radius-16",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/16"
+              }
+            },
+            {
+              "name": "border radius/border-radius-20",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/20"
+              }
+            },
+            {
+              "name": "border radius/border-radius-24",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/24"
+              }
+            },
+            {
+              "name": "border radius/border-radius-28",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/28"
+              }
+            },
+            {
+              "name": "border radius/border-radius-32",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/32"
+              }
+            },
+            {
+              "name": "border radius/border-radius-36",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/36"
+              }
+            },
+            {
+              "name": "border radius/border-radius-40",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/40"
+              }
+            },
+            {
+              "name": "border radius/border-radius-44",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/44"
+              }
+            },
+            {
+              "name": "border radius/border-radius-48",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/48"
+              }
+            },
+            {
+              "name": "border radius/border-radius-52",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/52"
+              }
+            },
+            {
+              "name": "border radius/border-radius-56",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/56"
+              }
+            },
+            {
+              "name": "border radius/border-radius-60",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/60"
+              }
+            },
+            {
+              "name": "border radius/border-radius-64",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/64"
+              }
+            },
+            {
+              "name": "border radius/border-radius-999",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/999"
+              }
             }
           ]
         }
@@ -1429,7 +3739,7 @@
                 "fontWeight": "Regular",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1445,7 +3755,7 @@
                 "fontWeight": "Medium",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1461,7 +3771,7 @@
                 "fontWeight": "SemiBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1477,7 +3787,7 @@
                 "fontWeight": "Bold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1493,7 +3803,7 @@
                 "fontWeight": "Regular",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1509,7 +3819,7 @@
                 "fontWeight": "Medium",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"
@@ -1525,7 +3835,7 @@
                 "fontWeight": "SemiBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
+                "letterSpacing": -1,
                 "letterSpacingUnit": "PERCENT",
                 "textCase": "ORIGINAL",
                 "textDecoration": "NONE"


### PR DESCRIPTION
## 📝 설명
textField 컴포넌트와 figma variables 업데이트에 따라 spacing관련 토큰을 tailwind 플러그인에 등록했습니다

## 🛠️ 주요 변경 사항
textField 컴포넌트 리팩토링 ce66acca5000e2dca7dd8b8b0b5f887436f25afd
variables.json 업데이트 47e8a26b37a58902e81eacafe3adea1058f80ddb

## 리뷰 시 고려해야 할 사항
- textField의 경우 기존 input을 대체하는 컴포넌트로, radix-ui의 의존성을 제거했습니다
- spacing 토큰은 tailwind spacing theme을 활용하여 기존의 사용법과 동일하게 사용 가능합니다(gap-1, rounded-2)
- 현재는 변경을 고려하여 `extend` 로 설정했습니다(기본 tailwind default테마를 override). 기존의 토큰값과 달라지기 때문에 실제 피그마와 싱크를 맞추는 작업이 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 앱 전반의 텍스트 입력을 새로운 TextField 디자인으로 통일하고 오류 표시 및 접근성(aria) 개선.
  * 팀 입력 행에 삭제(휴지통) 버튼 추가로 최소 팀 수 유지하며 쉽게 제거 가능.
  * Tailwind 테마에 간격·반경·단위 토큰을 도입해 일관된 간격 및 모서리 반경 적용.

* 리팩터링
  * 입력 컴포넌트를 TextField 기반으로 전면 교체하고 onChange/maxlength 처리 방식 정비.

* 문서
  * TextField용 Storybook 스토리 및 상호작용 검증 예제 추가.

* 작업
  * 디자인 토큰 생성 로직과 플러그인 연동 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->