### PR TITLE
middleware 로직 변경

### DIFF
--- a/service/app/src/middleware.ts
+++ b/service/app/src/middleware.ts
@@ -20,7 +20,7 @@ export function middleware(request: NextRequest) {
   if (
     isPageNavigation &&
     !isPublicAsset &&
-    (device.type === "mobile" || device.type === "tablet")
+    (device?.type === "mobile" || device?.type === "tablet")
   ) {
     return NextResponse.rewrite(new URL("/mobile", request.url))
   }

--- a/service/app/src/middleware.ts
+++ b/service/app/src/middleware.ts
@@ -1,17 +1,28 @@
-import { NextRequest, NextResponse } from "next/server"
-
-const hasValidSessionFromRequest = (req: NextRequest) => {
-  const sid = req.cookies.get("JSESSIONID")?.value
-  return !!sid
-}
+import { NextRequest, NextResponse, userAgent } from "next/server"
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/create/:path*"],
+  matcher: ["/:path*"],
 }
 
 export function middleware(request: NextRequest) {
-  if (!hasValidSessionFromRequest(request)) {
-    return NextResponse.redirect(new URL("/protected", request.url))
+  const { device } = userAgent(request)
+  const accept = request.headers.get("accept")
+  const isPageNavigation =
+    request.method === "GET" && accept?.includes("text/html")
+
+  const isPublicAsset =
+    request.nextUrl.pathname.startsWith("/_next") ||
+    request.nextUrl.pathname.startsWith("/api") ||
+    /\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml)$/i.test(
+      request.nextUrl.pathname,
+    )
+
+  if (
+    isPageNavigation &&
+    !isPublicAsset &&
+    (device.type === "mobile" || device.type === "tablet")
+  ) {
+    return NextResponse.rewrite(new URL("/mobile", request.url))
   }
   return NextResponse.next()
 }


### PR DESCRIPTION
## 📝 설명

middleware.ts 로직 변경

## 🛠️ 주요 변경 사항

- 현재 domain이 다른 문제로 next.js middleware에서 요청 쿠키를 읽을 수 없는 문제가 있어서, middleware.ts에서 요청에 쿠키가 담겨 있더라도 무조건 `/protected`로 리다이렉트하는 문제가 발생하고 있습니다. 때문에 이 부분은 임시로 제거했습니다. (프론트에서 proxy를 구성하거나 백엔드에서 내려주는 session의 도메인을 바꾸거나 ... 해결 방법 논의가 필요할 것 같습니다)
- 이전에 롤백했던 mobile 접속을 막는 middleware 로직의 오작동은 서버 셧다운 문제였던 것으로 판단되어 해당 로직을 되살렸습니다.

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 모바일·태블릿 사용자가 페이지를 방문할 때 자동으로 모바일 전용 경로(/mobile)로 안내되어 더 적합한 화면을 제공합니다.
* 변경 사항
  * 모든 페이지에 일관된 내비게이션 처리가 적용되어 동작이 예측 가능해졌습니다.
  * 이미지·폰트 등 공개 자산은 리다이렉트 없이 그대로 제공되어 로딩이 안정적입니다.
  * 이전의 세션 기반 강제 리다이렉트가 제거되어 불필요한 차단 없이 자연스러운 접근 흐름을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->