### PR TITLE
공통 컴포넌트 레이아웃 업데이트

### DIFF
--- a/shared/design/src/components/button/destructiveSolidIconButton.tsx
+++ b/shared/design/src/components/button/destructiveSolidIconButton.tsx
@@ -9,8 +9,8 @@ const destructiveSolidIconButtonVariants = cva(
   {
     variants: {
       size: {
-        md: "size-9 p-1.5",
-        lg: "size-11 p-2.5",
+        md: "size-36 p-1.5",
+        lg: "size-44 p-2.5",
       },
     },
     defaultVariants: {

--- a/shared/design/src/components/button/primaryBoxButton.tsx
+++ b/shared/design/src/components/button/primaryBoxButton.tsx
@@ -27,7 +27,7 @@ const primaryBoxButtonVariants = cva(
     compoundVariants: [
       {
         size: "sm",
-        className: "[&>svg]:mr-[2px] [&>svg]:size-8",
+        className: "[&>svg]:mr-[2px] [&>svg]:size-32",
       },
     ],
     defaultVariants: {

--- a/shared/design/src/components/button/primarySolidIconButton.tsx
+++ b/shared/design/src/components/button/primarySolidIconButton.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../utils/cn"
 import { BaseButton, type BaseButtonProps } from "./baseButton"
 
 const primarySolidIconButtonVariants = cva(
-  "inline-flex size-9 shrink-0 flex-row items-center justify-center gap-2.5 rounded-lg bg-background-interactive-primary p-1.5 text-icon-interactive-inverse hover:bg-background-interactive-primary-hovered active:bg-background-interactive-primary-pressed disabled:cursor-not-allowed disabled:bg-background-interactive-primary-disabled",
+  "inline-flex size-36 shrink-0 flex-row items-center justify-center gap-2.5 rounded-lg bg-background-interactive-primary p-1.5 text-icon-interactive-inverse hover:bg-background-interactive-primary-hovered active:bg-background-interactive-primary-pressed disabled:cursor-not-allowed disabled:bg-background-interactive-primary-disabled",
   {
     variants: {},
     defaultVariants: {},

--- a/shared/design/src/components/button/secondaryGhostIconButton.tsx
+++ b/shared/design/src/components/button/secondaryGhostIconButton.tsx
@@ -6,7 +6,7 @@ import { BaseButton, type BaseButtonProps } from "./baseButton"
 
 //44px - 아이콘은 24px
 const secondaryGhostIconButtonVariants = cva(
-  "inline-flex size-11 shrink-0 flex-row items-center justify-center gap-2.5 rounded-lg p-2.5 hover:bg-background-interactive-secondary-hovered active:bg-background-interactive-secondary-pressed disabled:bg-background-interactive-secondary-pressed [&>svg]:size-6",
+  "inline-flex size-44 shrink-0 flex-row items-center justify-center gap-2.5 rounded-lg p-2.5 hover:bg-background-interactive-secondary-hovered active:bg-background-interactive-secondary-pressed disabled:bg-background-interactive-secondary-pressed [&>svg]:size-24",
   {
     variants: {},
     defaultVariants: {},

--- a/shared/design/src/components/button/secondaryPlainIconButton.tsx
+++ b/shared/design/src/components/button/secondaryPlainIconButton.tsx
@@ -9,9 +9,9 @@ const secondaryPlainIconButtonVariants = cva(
   {
     variants: {
       size: {
-        sm: "size-6 [&>svg]:size-6",
-        md: "size-7 [&>svg]:size-7",
-        lg: "size-8 [&>svg]:size-8",
+        sm: "size-24 [&>svg]:size-24",
+        md: "size-28 [&>svg]:size-28",
+        lg: "size-32 [&>svg]:size-32",
       },
     },
     defaultVariants: {

--- a/shared/design/src/components/dialog/index.tsx
+++ b/shared/design/src/components/dialog/index.tsx
@@ -111,7 +111,7 @@ export const DialogHeader = ({
     <DialogPrimitive.Title
       data-slot="dialog-header"
       className={cn(
-        "typography-heading-md-semibold flex w-full flex-col items-center justify-center p-2.5 text-center text-text-primary",
+        "typography-heading-md-semibold flex w-full flex-col items-center justify-center break-keep p-2.5 text-center text-text-primary",
         className,
       )}
       {...props}
@@ -154,7 +154,7 @@ export const DialogBody = ({
       <DialogPrimitive.Description
         data-slot="dialog-body"
         className={cn(
-          "typography-body-lg-medium flex w-full flex-col items-center justify-center p-2.5 text-center text-text-secondary",
+          "typography-body-lg-medium flex w-full flex-col items-center justify-center break-keep p-2.5 text-center text-text-secondary",
           className,
         )}
         {...props}

--- a/shared/design/src/components/dialog/index.tsx
+++ b/shared/design/src/components/dialog/index.tsx
@@ -173,7 +173,7 @@ export const DialogFooter = ({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "flex w-full items-center justify-center gap-2 *:flex-1",
+        "flex w-full items-center justify-center gap-8 *:flex-1",
         className,
       )}
       {...props}

--- a/shared/design/src/components/gameCard/index.tsx
+++ b/shared/design/src/components/gameCard/index.tsx
@@ -73,7 +73,7 @@ const GameCardBadge = ({ children, className }: GameCardBadgeProps) => {
     <div
       aria-label="문제 수 배지"
       className={cn(
-        "absolute left-2 top-2 inline-flex items-center justify-center gap-[10px] rounded-[4px] bg-background-badge-primary px-[5px] py-[2px]",
+        "absolute left-8 top-8 inline-flex items-center justify-center gap-[10px] rounded-[4px] bg-background-badge-primary px-[5px] py-[2px]",
         className,
       )}
     >
@@ -90,7 +90,7 @@ const GameCardSharedBadge = ({ children, className }: GameCardBadgeProps) => {
       role="status"
       aria-label="공유 배지"
       className={cn(
-        "absolute bottom-2 left-2 inline-flex items-center justify-center gap-[10px] rounded-[2px] bg-background-badge-secondary px-[5px] py-[2px]",
+        "absolute bottom-8 left-8 inline-flex items-center justify-center gap-[10px] rounded-[2px] bg-background-badge-secondary px-[5px] py-[2px]",
         className,
       )}
     >

--- a/shared/design/src/components/gameCard/index.tsx
+++ b/shared/design/src/components/gameCard/index.tsx
@@ -53,7 +53,7 @@ const GameCardTitle = ({ children, className }: GameCardTitleProps) => {
     <div className="h-[46px] w-[178px]">
       <h3
         className={cn(
-          "line-clamp-2 h-[46px] w-[178px] overflow-hidden text-ellipsis text-[19px] font-bold leading-[120%] text-text-primary",
+          "line-clamp-2 h-[46px] w-[178px] overflow-hidden text-ellipsis break-keep text-[19px] font-bold leading-[120%] text-text-primary",
           className,
         )}
       >

--- a/shared/design/src/components/gameCreate/index.tsx
+++ b/shared/design/src/components/gameCreate/index.tsx
@@ -8,7 +8,7 @@ interface GameCreateProps {
 export const GameCreate = ({ onClick, className = "" }: GameCreateProps) => {
   return (
     <div
-      className={`flex w-[178px] cursor-pointer flex-col items-center gap-4 ${className}`}
+      className={`flex w-[178px] cursor-pointer flex-col items-center gap-16 ${className}`}
       onClick={onClick}
       role="button"
       aria-label="게임 만들기"

--- a/shared/design/src/components/input/index.tsx
+++ b/shared/design/src/components/input/index.tsx
@@ -33,7 +33,7 @@ const baseVariants = cva("flex flex-col items-start", {
 const labelVariants = cva("typography-heading-sm-semibold text-text-primary")
 
 const inputWrapperVariants = cva(
-  "flex w-full shrink-0 items-center gap-2 rounded-[5px] border-2 bg-background-interactive-input-primary",
+  "flex w-full shrink-0 items-center gap-8 rounded-[5px] border-2 bg-background-interactive-input-primary",
   {
     variants: {
       type: {
@@ -56,7 +56,7 @@ const inputWrapperVariants = cva(
 )
 
 const inputVariants = cva(
-  "flex-1 gap-2 bg-transparent text-text-interactive-input-filled placeholder:text-text-interactive-input-placeholder focus:outline-none",
+  "flex-1 gap-8 bg-transparent text-text-interactive-input-filled placeholder:text-text-interactive-input-placeholder focus:outline-none",
   {
     variants: {
       type: {
@@ -72,8 +72,8 @@ const inputVariants = cva(
 const iconVariants = cva("", {
   variants: {
     type: {
-      leftIcon: "size-4",
-      reset: "size-7",
+      leftIcon: "size-16",
+      reset: "size-28",
     },
   },
 })

--- a/shared/design/src/components/menu/index.tsx
+++ b/shared/design/src/components/menu/index.tsx
@@ -42,7 +42,7 @@ const menuItemVariants = cva(
   {
     variants: {
       type: {
-        icon: "w-[49px] flex-col items-center gap-[9px] p-0 [&>svg]:size-4",
+        icon: "w-[49px] flex-col items-center gap-[9px] p-0 [&>svg]:size-16",
         text: "w-[134px] flex-row gap-[10px] px-1",
       },
     },

--- a/shared/design/src/components/navigation/index.tsx
+++ b/shared/design/src/components/navigation/index.tsx
@@ -30,45 +30,39 @@ const navigationVariants = cva(
   },
 )
 
-const leftSectionVariants = cva(
-  "flex w-[420px] items-center gap-2.5 px-10",
-  {
-    variants: {
-      type: {
-        untitle: "",
-        title: "",
-        searchbar: "",
-        createGame: "",
-        startGame: "",
-        progressbar: "",
-        onGame: "",
-      },
-    },
-    defaultVariants: {
-      type: "untitle",
+const leftSectionVariants = cva("flex w-[420px] items-center gap-2.5 px-10", {
+  variants: {
+    type: {
+      untitle: "",
+      title: "",
+      searchbar: "",
+      createGame: "",
+      startGame: "",
+      progressbar: "",
+      onGame: "",
     },
   },
-)
+  defaultVariants: {
+    type: "untitle",
+  },
+})
 
-const centerSectionVariants = cva(
-  "flex items-center",
-  {
-    variants: {
-      type: {
-        untitle: "hidden",
-        title: "flex w-[1080px] justify-center",
-        searchbar: "flex h-[64px] w-[871px]",
-        createGame: "hidden",
-        startGame: "flex w-[1080px] justify-center",
-        progressbar: "flex w-[1080px] justify-center",
-        onGame: "flex w-[1080px] justify-center",
-      },
-    },
-    defaultVariants: {
-      type: "untitle",
+const centerSectionVariants = cva("flex items-center", {
+  variants: {
+    type: {
+      untitle: "hidden",
+      title: "flex w-[1080px] justify-center",
+      searchbar: "flex h-[64px] w-[871px]",
+      createGame: "hidden",
+      startGame: "flex w-[1080px] justify-center",
+      progressbar: "flex w-[1080px] justify-center",
+      onGame: "flex w-[1080px] justify-center",
     },
   },
-)
+  defaultVariants: {
+    type: "untitle",
+  },
+})
 
 const rightSectionVariants = cva(
   "flex w-[420px] flex-col items-end justify-center gap-2.5",
@@ -90,25 +84,22 @@ const rightSectionVariants = cva(
   },
 )
 
-const rightContainerVariants = cva(
-  "flex items-center gap-4 px-10",
-  {
-    variants: {
-      type: {
-        untitle: "h-[48px]",
-        title: "h-[44px]",
-        searchbar: "h-[48px]",
-        createGame: "h-[44px]",
-        startGame: "h-[44px]",
-        progressbar: "h-[44px]",
-        onGame: "h-[44px]",
-      },
-    },
-    defaultVariants: {
-      type: "untitle",
+const rightContainerVariants = cva("flex items-center gap-16 px-10", {
+  variants: {
+    type: {
+      untitle: "h-[48px]",
+      title: "h-[44px]",
+      searchbar: "h-[48px]",
+      createGame: "h-[44px]",
+      startGame: "h-[44px]",
+      progressbar: "h-[44px]",
+      onGame: "h-[44px]",
     },
   },
-)
+  defaultVariants: {
+    type: "untitle",
+  },
+})
 
 export type NavigationVariantProps = VariantProps<typeof navigationVariants>
 
@@ -120,16 +111,17 @@ interface NavigationProps extends NavigationVariantProps {
 }
 
 export const Navigation = forwardRef<HTMLElement, NavigationProps>(
-  ({ className, type, playGame, leftContent, centerContent, rightContent }, ref) => {
+  (
+    { className, type, playGame, leftContent, centerContent, rightContent },
+    ref,
+  ) => {
     return (
       <nav
         ref={ref}
         className={cn(navigationVariants({ type, playGame }), className)}
       >
         {/* Left Section */}
-        <div className={cn(leftSectionVariants({ type }))}>
-          {leftContent}
-        </div>
+        <div className={cn(leftSectionVariants({ type }))}>{leftContent}</div>
 
         {/* Center Section */}
         <div className={cn(centerSectionVariants({ type }))}>

--- a/shared/design/src/components/playerStatus/index.tsx
+++ b/shared/design/src/components/playerStatus/index.tsx
@@ -28,7 +28,7 @@ export const PlayerStatus = ({
       role="group"
       aria-label={`${name} 점수 카드`}
     >
-      <div className="flex h-10 min-h-10 max-w-[310px] flex-1 items-center justify-center gap-5">
+      <div className="flex h-10 min-h-10 max-w-[310px] flex-1 items-center justify-center gap-20">
         <h3
           className={`typography-heading-xl-medium flex h-10 min-w-0 items-center text-center ${scoreView ? "flex-1" : "w-full"}`}
         >

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -165,7 +165,7 @@ const QuestionMoveButtons = ({
 
   return (
     <div
-      className={`absolute right-4 top-5 flex flex-col items-center gap-5 ${className}`}
+      className={`absolute right-4 top-5 flex flex-col items-center gap-20 ${className}`}
     >
       <SecondaryPlainIconButton
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
@@ -203,7 +203,7 @@ const QuestionActions = ({
   className = "",
 }: QuestionActionsProps) => {
   return (
-    <div className={`flex items-center gap-2 ${className}`}>{children}</div>
+    <div className={`flex items-center gap-8 ${className}`}>{children}</div>
   )
 }
 

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -130,7 +130,7 @@ const QuestionDeleteButton = ({
   const deleteLabel = index ? `${index}번째 문제 삭제` : "문제 삭제"
 
   return (
-    <div className={`absolute bottom-4 left-4 ${className}`}>
+    <div className={`absolute bottom-[10px] left-[14px] ${className}`}>
       <DestructiveSolidIconButton
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation()
@@ -165,7 +165,7 @@ const QuestionMoveButtons = ({
 
   return (
     <div
-      className={`absolute right-4 top-5 flex flex-col items-center gap-20 ${className}`}
+      className={`absolute right-16 top-20 flex flex-col items-center gap-20 ${className}`}
     >
       <SecondaryPlainIconButton
         onClick={(e: MouseEvent<HTMLButtonElement>) => {

--- a/shared/design/src/components/question/index.tsx
+++ b/shared/design/src/components/question/index.tsx
@@ -78,7 +78,7 @@ const QuestionTitle = ({ children, className = "" }: QuestionTitleProps) => {
 
   return (
     <h3
-      className={`typography-heading-sm-medium line-clamp-1 overflow-hidden text-ellipsis pr-[157px] pt-1 text-text-primary ${className}`}
+      className={`typography-heading-sm-medium line-clamp-1 overflow-hidden text-ellipsis break-keep pr-[157px] pt-1 text-text-primary ${className}`}
     >
       {state === "error" ? <>❗ {children}</> : children}
     </h3>

--- a/shared/design/src/components/textField/index.tsx
+++ b/shared/design/src/components/textField/index.tsx
@@ -23,7 +23,7 @@ const baseVariants = "flex w-full flex-col items-start space-y-5"
 const labelVariants = "typography-heading-sm-semibold text-text-primary"
 
 const inputWrapperVariants = cva(
-  "flex w-full shrink-0 items-center gap-2 rounded-[8px] border-2 bg-background-interactive-input-primary p-[20px]",
+  "flex w-full shrink-0 items-center gap-8 rounded-[8px] border-2 bg-background-interactive-input-primary p-[20px]",
   {
     variants: {
       state: {
@@ -40,7 +40,7 @@ const inputWrapperVariants = cva(
 )
 
 const inputVariants =
-  "typography-heading-sm-medium flex-1 gap-2 bg-transparent text-text-interactive-input-filled placeholder:text-text-interactive-input-placeholder focus:outline-none"
+  "typography-heading-sm-medium flex-1 gap-8 bg-transparent text-text-interactive-input-filled placeholder:text-text-interactive-input-placeholder focus:outline-none"
 
 const errorTextVariants =
   "typography-body-sm-medium -mt-2 text-text-interactive-input-error"
@@ -202,7 +202,7 @@ export const LeftAddon = forwardRef<
     <div
       ref={ref}
       className={cn(
-        "flex size-4 shrink-0 items-center justify-center",
+        "flex size-16 shrink-0 items-center justify-center",
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📝 설명

- 길이 관련 design token 도입 이후, 토큰 덮어쓰기로 인해 레이아웃이 망가진 것들을 복구했습니다 (`service/app` 내부에만 있는 컴포넌트들은 아직 건드리지 않았습니다)

  - px 값으로 직접 들어가 있는 것들은 건드리지 않았음 (ex. - `h-[46px]`)
  - 변환했을 때 4의 배수가 아닌 경우 적용하지 않음 (ex - `gap-2.5`), 4의 배수로 변환되는 값들만 새로운 토큰으로 갱신

제가 직접 작업한 것들이라 빠뜨린 부분이 있을 수도 있는데 발견하는대로 수정해서 올리겠습니다... (gap, size 위주로 작업해서 top, bottom, left, right, p 속성에서 빠진 부분이 아직 있을 것 같습니다)

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 스타일
  - 아이콘 버튼(기본/보조/파괴적) 전반 크기 및 아이콘 크기 확대
  - 입력/텍스트 필드 내부 간격 및 아이콘 크기 증가
  - 메뉴 항목 아이콘 크기 증가
  - 다이얼로그 헤더/바디 줄바꿈 보존 및 푸터 버튼 간격 확대
  - 게임 카드 배지 위치 조정 및 타이틀 줄바꿈 동작 보강
  - 질문 삭제/이동/액션 버튼 위치·간격 조정
  - 게임 생성·플레이어 상태 레이아웃 간격 확대
- 리팩터
  - 내비게이션 구현 정리(동작·공개 API 변화 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->