### PR TITLE
game preview 레이아웃 조정

### DIFF
--- a/service/app/src/entities/game/ui/components/gamePreview.tsx
+++ b/service/app/src/entities/game/ui/components/gamePreview.tsx
@@ -112,11 +112,9 @@ export const GamePreview = ({
                   <GameCard.Root key={question.id}>
                     {question.imageUrl ? (
                       <GameCard.Image
-                        className="h-[260px]"
+                        className="h-[260px] w-[178px]"
                         src={question.imageUrl}
                         alt={question.title}
-                        fill
-                        sizes="178px"
                         placeholder="blur"
                         blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
                       />

--- a/service/app/src/entities/game/ui/components/gamePreview.tsx
+++ b/service/app/src/entities/game/ui/components/gamePreview.tsx
@@ -110,15 +110,13 @@ export const GamePreview = ({
               >
                 {questions.map((question, _index) => (
                   <GameCard.Root key={question.id}>
-                    {question.imageUrl ? (
-                      <GameCard.Image
-                        className="h-[260px] w-[178px]"
-                        src={question.imageUrl}
-                        alt={question.title}
-                        placeholder="blur"
-                        blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
-                      />
-                    ) : null}
+                    <GameCard.Image
+                      className="h-[260px] w-[178px]"
+                      src={question.imageUrl ?? "/checker.svg"}
+                      alt={question.title}
+                      placeholder="blur"
+                      blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
+                    />
                     <GameCard.Description>
                       {question.title}
                     </GameCard.Description>


### PR DESCRIPTION
## 📝 설명

- game preview 레이아웃 변경
    - 기본 이미지 크기 178*178에서 178 * 260으로 변경 (피그마랑 동일하게)
    - 이미지가 없는 문제의 경우 checker.svg를 사용하도록 변경

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임 카드 이미지 표시 방식을 개선했습니다. 이제 이미지가 고정된 크기로 일관되게 표시되며, 이미지를 사용할 수 없을 때 대체 이미지가 표시됩니다. 이미지 로드 중 흐림 효과는 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->