### PR TITLE
컴포넌트 레벨에서 동작하는 auth guard 추가

### DIFF
--- a/service/app/src/app/create/page.tsx
+++ b/service/app/src/app/create/page.tsx
@@ -1,11 +1,15 @@
 "use client"
 
+import { useAuthGuard } from "@/entities/auth/model/hooks/useAuthGuard"
+
 import { CreateGameNavigation } from "./components/createGameNavigation"
 import { FileUploadArea } from "./components/fileUploadArea"
 import { QuestionInputForm } from "./components/questionInputForm"
 import { QuestionList } from "./components/questionList"
 
 export default function CreateGamePage() {
+  useAuthGuard()
+
   return (
     <main className="flex h-screen flex-col overflow-hidden bg-background-primary">
       <CreateGameNavigation />

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { overlay } from "overlay-kit"
 import { useEffect, useState } from "react"
 
 import { useAuthStore } from "@/entities/auth"
+import { useAuthGuard } from "@/entities/auth/model/hooks/useAuthGuard"
 import { GameListItem } from "@/entities/game"
 import { deleteGame, getGameDetail } from "@/entities/game/api"
 import { GameQuestion } from "@/entities/game/model/game"
@@ -22,6 +23,8 @@ import { GamePreview } from "@/entities/game/ui/components/gamePreview"
 import AvatarButton from "@/widgets/components/avatarButton"
 
 export default function DashboardPage() {
+  useAuthGuard()
+
   const router = useRouter()
   const queryClient = useQueryClient()
   const [_searchQuery, _setSearchQuery] = useState("")

--- a/service/app/src/app/login/kakao/page.tsx
+++ b/service/app/src/app/login/kakao/page.tsx
@@ -26,10 +26,10 @@ function KakaoCallbackContent() {
   }, [searchParams, login, router])
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center">
-        <div className="mb-4">카카오 로그인 처리 중...</div>
-        <div className="mx-auto size-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
+    <div className="flex min-h-screen items-center justify-center bg-background-primary">
+      <div className="flex flex-col items-center gap-16">
+        <div className="size-32 animate-spin rounded-full border-4 border-blue-400 border-t-transparent"></div>
+        <p className="text-sm text-text-primary">카카오 로그인 처리 중...</p>
       </div>
     </div>
   )

--- a/service/app/src/app/login/page.tsx
+++ b/service/app/src/app/login/page.tsx
@@ -26,8 +26,8 @@ export default function KakaoLoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background-primary">
-      <div className="flex flex-col items-center gap-4">
-        <div className="size-8 animate-spin rounded-full border-4 border-blue-400 border-t-transparent"></div>
+      <div className="flex flex-col items-center gap-16">
+        <div className="size-32 animate-spin rounded-full border-4 border-blue-400 border-t-transparent"></div>
         <p className="text-sm text-text-primary">
           카카오 로그인으로 이동 중...
         </p>

--- a/service/app/src/entities/auth/model/hooks/useAuthGuard.ts
+++ b/service/app/src/entities/auth/model/hooks/useAuthGuard.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+import { useAuthStore } from "../../store/useAuthStore"
+
+export const useAuthGuard = () => {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthStore()
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.")
+      router.push("/")
+    }
+  }, [isAuthenticated, router])
+}

--- a/service/app/src/entities/auth/model/hooks/useAuthGuard.ts
+++ b/service/app/src/entities/auth/model/hooks/useAuthGuard.ts
@@ -7,12 +7,14 @@ import { useAuthStore } from "../../store/useAuthStore"
 
 export const useAuthGuard = () => {
   const router = useRouter()
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, _hasHydrated } = useAuthStore()
 
   useEffect(() => {
+    if (!_hasHydrated) return
+
     if (!isAuthenticated) {
       alert("로그인이 필요합니다.")
-      router.push("/")
+      router.replace("/")
     }
-  }, [isAuthenticated, router])
+  }, [isAuthenticated, _hasHydrated, router])
 }

--- a/service/app/src/entities/auth/store/useAuthStore.ts
+++ b/service/app/src/entities/auth/store/useAuthStore.ts
@@ -9,6 +9,7 @@ import { deleteCookie, getSessionId } from "../utils/cookieUtils"
 type AuthState = {
   user: KakaoLoginData | null
   isAuthenticated: boolean
+  _hasHydrated: boolean
   login: (code: string) => Promise<void>
   logout: () => void
 }
@@ -18,6 +19,7 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       user: null,
       isAuthenticated: !!getSessionId(),
+      _hasHydrated: false,
 
       login: async (code: string) => {
         try {
@@ -37,6 +39,11 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "auth-store",
       storage: createJSONStorage(() => sessionStorage),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state._hasHydrated = true
+        }
+      },
     },
   ),
 )

--- a/service/app/src/entities/auth/store/useAuthStore.ts
+++ b/service/app/src/entities/auth/store/useAuthStore.ts
@@ -39,6 +39,10 @@ export const useAuthStore = create<AuthState>()(
     {
       name: "auth-store",
       storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+      }),
       onRehydrateStorage: () => (state) => {
         if (state) {
           state._hasHydrated = true


### PR DESCRIPTION
## 📝 설명

- 인증되지 않은 사용자의 접근을 막는 `useAuthGuard` 훅 생성
    - '로그인이 필요합니다' alert
    - 홈 화면으로 리다이렉트

- `/dashboard`, `/create` 페이지에 해당 훅 적용

- 카카오 로그인 중 보이는 spinner ui의 디자인 조정 (디자인 토큰 등록 이후 발생한 레이아웃 불일치 조정 / 두 로딩 스피너의 디자인 통일)

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임 생성 및 대시보드에 클라이언트 인증 가드 적용 (비로그인 시 리디렉션)
  * 인증 상태 지속화 시 하이드레이션 상태 추적 추가

* **Style**
  * 로그인 페이지 로더 크기 및 간격 확대
  * Kakao 콜백 페이지 레이아웃 및 스타일 개선 (배경·정렬·스피너 색상/크기 조정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->