### PR TITLE
themetoggle 버튼 적용

### DIFF
--- a/service/app/src/app/create/components/createGameNavigation.tsx
+++ b/service/app/src/app/create/components/createGameNavigation.tsx
@@ -5,12 +5,12 @@ import {
   SecondaryGhostIconButton,
 } from "@shared/design/src/components/button"
 import * as TextField from "@shared/design/src/components/textField"
-import { ThemeToggle } from "@shared/design/src/components/themeToggle"
 import { Cross } from "@shared/design/src/icons"
 import { useRouter } from "next/navigation"
 import { useShallow } from "zustand/react/shallow"
 
 import { saveNewGame, updateExistingGame } from "@/entities/game/utils/gameSave"
+import { ThemeToggle } from "@/shared/themeToggleButton"
 
 import { useCreateGameStore } from "../store/useCreateGameStore"
 import { openErrorDialog } from "./dialog/errorDialog"

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -2,7 +2,6 @@
 
 import { PrimaryBoxButton } from "@shared/design/src/components/button"
 import { Navigation } from "@shared/design/src/components/navigation"
-import { ThemeToggle } from "@shared/design/src/components/themeToggle"
 import { Add } from "@shared/design/src/icons"
 import { useQueryClient } from "@tanstack/react-query"
 import Image from "next/image"
@@ -20,6 +19,7 @@ import { useGameShareActions } from "@/entities/game/model/useGameShareActions"
 import { useInfiniteMyGames } from "@/entities/game/model/useInfiniteMyGames"
 import { GameLibraryGrid } from "@/entities/game/ui/components"
 import { GamePreview } from "@/entities/game/ui/components/gamePreview"
+import { ThemeToggle } from "@/shared/themeToggleButton"
 import AvatarButton from "@/widgets/components/avatarButton"
 
 export default function DashboardPage() {

--- a/service/app/src/app/dashboard/page.tsx
+++ b/service/app/src/app/dashboard/page.tsx
@@ -1,15 +1,10 @@
 "use client"
 
-import { PrimaryBoxButton } from "@shared/design/src/components/button"
-import { Navigation } from "@shared/design/src/components/navigation"
-import { Add } from "@shared/design/src/icons"
 import { useQueryClient } from "@tanstack/react-query"
-import Image from "next/image"
 import { useRouter } from "next/navigation"
 import { overlay } from "overlay-kit"
 import { useEffect, useState } from "react"
 
-import { useAuthStore } from "@/entities/auth"
 import { useAuthGuard } from "@/entities/auth/model/hooks/useAuthGuard"
 import { GameListItem } from "@/entities/game"
 import { deleteGame, getGameDetail } from "@/entities/game/api"
@@ -19,8 +14,7 @@ import { useGameShareActions } from "@/entities/game/model/useGameShareActions"
 import { useInfiniteMyGames } from "@/entities/game/model/useInfiniteMyGames"
 import { GameLibraryGrid } from "@/entities/game/ui/components"
 import { GamePreview } from "@/entities/game/ui/components/gamePreview"
-import { ThemeToggle } from "@/shared/themeToggleButton"
-import AvatarButton from "@/widgets/components/avatarButton"
+import { DashboardNavigation } from "@/widgets/DashboardNavigation"
 
 export default function DashboardPage() {
   useAuthGuard()
@@ -28,7 +22,6 @@ export default function DashboardPage() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [_searchQuery, _setSearchQuery] = useState("")
-  const { logout } = useAuthStore()
 
   const {
     games,
@@ -130,62 +123,9 @@ export default function DashboardPage() {
     })
   }
 
-  const handleLogoClick = () => {
-    router.push("/")
-  }
-
-  const handleLogoutClick = () => {
-    logout()
-    router.push("/")
-  }
-
-  const leftContent = (
-    <button
-      className="flex h-[60px] w-[268px] cursor-pointer items-center justify-center p-3.5"
-      onClick={handleLogoClick}
-      aria-label="홈으로 이동"
-    >
-      <Image
-        src="/logo.svg"
-        alt="홈 로고"
-        className="size-full"
-        width={268}
-        height={60}
-      />
-    </button>
-  )
-
-  const centerContent = (
-    <h1 className="typography-heading-xl-semibold text-text-primary">
-      내 게임
-    </h1>
-  )
-
-  const rightContent = (
-    <>
-      <PrimaryBoxButton
-        size="sm"
-        _style="solid"
-        onClick={handleCreateGame}
-        aria-label="게임 만들기"
-      >
-        <Add />
-        게임 만들기
-      </PrimaryBoxButton>
-
-      <AvatarButton onClick={handleLogoutClick} />
-
-      <ThemeToggle />
-    </>
-  )
-
   return (
     <main className="min-h-screen bg-background-primary">
-      <Navigation
-        leftContent={leftContent}
-        centerContent={centerContent}
-        rightContent={rightContent}
-      />
+      <DashboardNavigation />
       <div className="flex w-full flex-col items-center gap-[45px] pt-[40px]">
         <GameLibraryGrid
           games={games}

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
@@ -1,11 +1,12 @@
 import {
   PrimaryBoxButton,
-  SecondaryGhostIconButton,
   SecondaryPlainIconButton,
 } from "@ject-5-fe/design/components/button"
 import { Progress } from "@ject-5-fe/design/components/progress"
-import { Cross, Sun } from "@ject-5-fe/design/icons"
+import { Cross } from "@ject-5-fe/design/icons"
 import Image from "next/image"
+
+import { ThemeToggle } from "@/shared/themeToggleButton"
 
 interface GamePlayHeaderProps {
   currentRound: number
@@ -49,9 +50,7 @@ export const GamePlayHeader = ({
 
       <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
         <div className="flex items-center justify-end gap-4 px-10">
-          <SecondaryGhostIconButton>
-            <Sun />
-          </SecondaryGhostIconButton>
+          <ThemeToggle />
 
           {currentRound > 1 && (
             <PrimaryBoxButton size="sm" _style="solid" onClick={onPrevQuestion}>

--- a/service/app/src/app/game/[gameId]/result/components/gameResultNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/result/components/gameResultNavigation.tsx
@@ -1,10 +1,11 @@
 import {
   PrimaryBoxButton,
-  SecondaryGhostIconButton,
   SecondaryPlainIconButton,
 } from "@ject-5-fe/design/components/button"
-import { Cross, Sun } from "@ject-5-fe/design/icons"
+import { Cross } from "@ject-5-fe/design/icons"
 import Image from "next/image"
+
+import { ThemeToggle } from "@/shared/themeToggleButton"
 
 interface GameResultNavigationProps {
   onGoHome: () => void
@@ -38,9 +39,7 @@ export const GameResultNavigation = ({
 
       <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
         <div className="flex items-center justify-end gap-4 px-10">
-          <SecondaryGhostIconButton>
-            <Sun />
-          </SecondaryGhostIconButton>
+          <ThemeToggle />
 
           <PrimaryBoxButton
             size="sm"

--- a/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/setup/components/gameNavigation.tsx
@@ -3,12 +3,13 @@ import {
   PrimaryBoxButton,
   SecondaryPlainIconButton,
 } from "@ject-5-fe/design/components/button"
-import { ThemeToggle } from "@ject-5-fe/design/components/themeToggle"
 import { Cross } from "@ject-5-fe/design/icons"
 import { Navigation } from "@shared/design/src/components/navigation"
 import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+
+import { ThemeToggle } from "@/shared/themeToggleButton"
 
 import { openExitConfirmDialog } from "../../components/dialogs/exitConfirmDialog"
 import { useGameStore } from "../../store/useGameStore"

--- a/service/app/src/app/games/page.tsx
+++ b/service/app/src/app/games/page.tsx
@@ -1,11 +1,5 @@
 "use client"
 
-import * as TextField from "@ject-5-fe/design/components/textField"
-import { Navigation } from "@shared/design/src/components/navigation"
-import { Magnifier } from "@shared/design/src/icons"
-import dynamic from "next/dynamic"
-import Image from "next/image"
-import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { overlay } from "overlay-kit"
 import { useState } from "react"
@@ -16,10 +10,7 @@ import { GameQuestion } from "@/entities/game/model/game"
 import { useInfiniteGameList } from "@/entities/game/model/useInfiniteGameList"
 import { GameLibraryGrid } from "@/entities/game/ui/components"
 import { GamePreview } from "@/entities/game/ui/components/gamePreview"
-
-const GamesAuthButton = dynamic(() => import("@/shared/authButton.tsx"), {
-  ssr: false,
-})
+import { GamesNavigation } from "@/widgets/GamesNavigation"
 
 export default function GamesPage() {
   const router = useRouter()
@@ -90,32 +81,11 @@ export default function GamesPage() {
     setSearchQuery(e.target.value)
   }
 
-  const leftContent = (
-    <Link href="/" aria-label="홈으로 이동">
-      <Image src="/logo.svg" alt="홈 로고" width={268} height={60} />
-    </Link>
-  )
-
-  const centerContent = (
-    <div className="hidden w-full max-w-[871px] md:flex">
-      <TextField.Root name="game" className="w-full">
-        <TextField.InputWrapper>
-          <Magnifier className="size-32 text-icon-interactive-input-default" />
-          <TextField.Input
-            onChange={handleSearchChange}
-            placeholder="오늘의 추천 게임은?"
-          ></TextField.Input>
-        </TextField.InputWrapper>
-      </TextField.Root>
-    </div>
-  )
-
   return (
     <>
-      <Navigation
-        leftContent={leftContent}
-        centerContent={centerContent}
-        rightContent={<GamesAuthButton />}
+      <GamesNavigation
+        searchQuery={searchQuery}
+        onSearchChange={handleSearchChange}
       />
       <div className="flex w-full flex-col items-center gap-[45px] pt-[40px]">
         <GameLibraryGrid

--- a/service/app/src/widgets/DashboardNavigation.tsx
+++ b/service/app/src/widgets/DashboardNavigation.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { Navigation } from "@shared/design/src/components/navigation"
+
+import DashboardNavigationRightContent from "./components/dashboardNavigationRightContent"
+import { HomeButton } from "./components/homeButton"
+
+interface DashboardNavigationProps {
+  className?: string
+}
+
+export const DashboardNavigation = ({
+  className,
+}: DashboardNavigationProps) => {
+  return (
+    <Navigation
+      className={className}
+      leftContent={<HomeButton />}
+      centerContent={
+        <h1 className="typography-heading-xl-semibold text-text-primary">
+          내 게임
+        </h1>
+      }
+      rightContent={<DashboardNavigationRightContent />}
+    />
+  )
+}

--- a/service/app/src/widgets/GamesNavigation.tsx
+++ b/service/app/src/widgets/GamesNavigation.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as TextField from "@ject-5-fe/design/components/textField"
+import { Navigation } from "@shared/design/src/components/navigation"
+import { Magnifier } from "@shared/design/src/icons"
+import dynamic from "next/dynamic"
+
+import { ThemeToggle } from "@/shared/themeToggleButton"
+
+import { HomeButton } from "./components/homeButton"
+
+const GamesAuthButton = dynamic(() => import("@/shared/authButton"), {
+  ssr: false,
+})
+
+interface GamesNavigationProps {
+  className?: string
+  searchQuery?: string
+  onSearchChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export const GamesNavigation = ({
+  className,
+  searchQuery = "",
+  onSearchChange,
+}: GamesNavigationProps) => {
+  return (
+    <Navigation
+      className={className}
+      leftContent={<HomeButton />}
+      centerContent={
+        <div className="hidden w-full max-w-[871px] md:flex">
+          <TextField.Root name="game" className="w-full">
+            <TextField.InputWrapper>
+              <Magnifier className="size-32 text-icon-interactive-input-default" />
+              <TextField.Input
+                value={searchQuery}
+                onChange={onSearchChange}
+                placeholder="오늘의 추천 게임은?"
+              />
+            </TextField.InputWrapper>
+          </TextField.Root>
+        </div>
+      }
+      rightContent={
+        <>
+          <GamesAuthButton />
+          <ThemeToggle />
+        </>
+      }
+    />
+  )
+}

--- a/service/app/src/widgets/components/dashboardNavigationRightContent.tsx
+++ b/service/app/src/widgets/components/dashboardNavigationRightContent.tsx
@@ -2,24 +2,20 @@
 
 import { PrimaryBoxButton } from "@shared/design/src/components/button"
 import { Add } from "@shared/design/src/icons"
+import dynamic from "next/dynamic"
 import { useRouter } from "next/navigation"
 
-import { useAuthStore } from "@/entities/auth"
 import { ThemeToggle } from "@/shared/themeToggleButton"
 
-import AvatarButton from "./avatarButton"
+const AuthButton = dynamic(() => import("@/shared/authButton"), {
+  ssr: false,
+})
 
 export default function DashboardNavigationRightContent() {
   const router = useRouter()
-  const { logout } = useAuthStore()
 
   const handleCreateGame = () => {
     router.push("/create")
-  }
-
-  const handleLogoutClick = () => {
-    logout()
-    router.push("/")
   }
 
   return (
@@ -34,7 +30,7 @@ export default function DashboardNavigationRightContent() {
         게임 만들기
       </PrimaryBoxButton>
 
-      <AvatarButton onClick={handleLogoutClick} />
+      <AuthButton />
 
       <ThemeToggle />
     </>

--- a/service/app/src/widgets/components/dashboardNavigationRightContent.tsx
+++ b/service/app/src/widgets/components/dashboardNavigationRightContent.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { PrimaryBoxButton } from "@shared/design/src/components/button"
+import { Add } from "@shared/design/src/icons"
+import { useRouter } from "next/navigation"
+
+import { useAuthStore } from "@/entities/auth"
+import { ThemeToggle } from "@/shared/themeToggleButton"
+
+import AvatarButton from "./avatarButton"
+
+export default function DashboardNavigationRightContent() {
+  const router = useRouter()
+  const { logout } = useAuthStore()
+
+  const handleCreateGame = () => {
+    router.push("/create")
+  }
+
+  const handleLogoutClick = () => {
+    logout()
+    router.push("/")
+  }
+
+  return (
+    <>
+      <PrimaryBoxButton
+        size="sm"
+        _style="solid"
+        onClick={handleCreateGame}
+        aria-label="게임 만들기"
+      >
+        <Add />
+        게임 만들기
+      </PrimaryBoxButton>
+
+      <AvatarButton onClick={handleLogoutClick} />
+
+      <ThemeToggle />
+    </>
+  )
+}


### PR DESCRIPTION
## 📝 설명

- dashboard, games 페이지의 네비게이션은 별도 컴포넌트로 분리
    - games 네비게이션의 경우 dynamic import 적용
- themetoggle이 사용되고 있는 곳들의 로직을 최신화 (import를 새로 만든 themetoggle로 연결)
- games 네비게이션에 themetoggle 버튼이 누락되어 있는 걸 발견해서 추가

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 앱 네비게이션 구조를 통합·단순화하여 헤더 구성과 탐색 흐름을 일관되게 정리
  * 대시보드 및 게임 관련 페이지의 헤더/내비게이션 UI 간소화

* **새 기능**
  * 대시보드 전용 네비게이션 컴포넌트 추가로 페이지 책임 분리
  * 게임 목록 페이지에 전용 네비게이션(검색·인증·테마 토글 포함) 도입
  * 대시보드 우측에 빠른 게임 생성 버튼 및 인증/테마 토글 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->