### PR TITLE
게임 수정 이미지 url 깨짐 이슈 대응

### DIFF
--- a/service/app/src/app/create/__tests__/createPOM.ts
+++ b/service/app/src/app/create/__tests__/createPOM.ts
@@ -144,11 +144,14 @@ export class CreatePOM {
   }
 
   async fillQuestionAndAnswer(question: string, answer: string) {
+    await this.questionInput.clear()
+    await this.answerInput.clear()
     await this.fillQuestionInput(question)
     await this.fillAnswerInput(answer)
   }
 
   async fillGameName(gameName: string) {
+    await this.gameNameInput.clear()
     await this.gameNameInput.fill(gameName)
   }
 

--- a/service/app/src/entities/game/utils/gameSave.ts
+++ b/service/app/src/entities/game/utils/gameSave.ts
@@ -57,7 +57,7 @@ export const saveNewGame = async (state: CreateGameState): Promise<UUID> => {
     gameThumbnailUrl: firstImageKey,
     questions: state.questions.map((question) => ({
       questionOrder: question.order,
-      imageUrl: imageUrlMap.get(question.order) || "",
+      imageUrl: imageUrlMap.get(question.order) ?? "",
       questionText: question.text.trim(),
       questionAnswer: question.answer.trim(),
     })),
@@ -130,7 +130,7 @@ export const updateExistingGame = async (
     gameThumbnailUrl: firstImageKey,
     questions: state.questions.map((question) => ({
       questionOrder: question.order,
-      imageUrl: imageUrlMap.get(question.order) || question.imageUrl,
+      imageUrl: imageUrlMap.get(question.order) ?? (question.imageUrl || null),
       questionText: question.text.trim(),
       questionAnswer: question.answer.trim(),
     })),


### PR DESCRIPTION
## 📝 설명

imageUrl에 빈 값이면 null이 아니라 "" (빈 문자열)을 사용하도록 해 두어서, 이 값이 백엔드에 저장된 다음 이후 렌더링할 때 src가 깨짐
-> 게임 수정에서 신규 이미지를 등록하지 않고, 문제, 답안만 수정할 경우 기존의 이미지가 깨지는 이슈로 대응됨
null을 허용하는 값을 사용하여 문제 해결

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임 저장 시 이미지 URL 처리 방식을 개선하여 누락되거나 불명확한 이미지 값이 더 안정적으로 처리됩니다.
* **테스트**
  * 입력 초기화 동작을 보장하도록 테스트 흐름을 정비해, 입력값 관련 회귀를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->