### PR TITLE
이모지 깨짐 이슈 대응

### DIFF
--- a/service/app/src/app/create/__tests__/create.spec.ts
+++ b/service/app/src/app/create/__tests__/create.spec.ts
@@ -138,7 +138,10 @@ test.describe("게임 생성 페이지: 게임 수정", () => {
     await pageObj.saveGame()
     const gameCard = page.getByRole("group", { name: "게임 카드" }).first()
     gameCard.click()
-    await expect(page.getByText("문제 1 테스트 수정")).toBeVisible()
+    const gamePreview = page.getByRole("dialog")
+    await expect(gamePreview).toBeVisible()
+    const gamePreviewQuestions = page.getByTestId("game-preview-questions")
+    await expect(gamePreviewQuestions.first()).toHaveText("문제 1 테스트 수정")
   })
 })
 

--- a/service/app/src/app/create/__tests__/create.spec.ts
+++ b/service/app/src/app/create/__tests__/create.spec.ts
@@ -140,8 +140,11 @@ test.describe("게임 생성 페이지: 게임 수정", () => {
     gameCard.click()
     const gamePreview = page.getByRole("dialog")
     await expect(gamePreview).toBeVisible()
-    const gamePreviewQuestions = page.getByTestId("game-preview-questions")
-    await expect(gamePreviewQuestions.first()).toHaveText("문제 1 테스트 수정")
+    const gamePreviewQuestion = page
+      .getByTestId("game-preview-questions")
+      .locator("p")
+      .first()
+    await expect(gamePreviewQuestion).toHaveText("문제 1 테스트 수정")
   })
 })
 

--- a/service/app/src/app/create/__tests__/createPOM.ts
+++ b/service/app/src/app/create/__tests__/createPOM.ts
@@ -136,10 +136,12 @@ export class CreatePOM {
   }
 
   async fillQuestionInput(question: string) {
+    await this.questionInput.clear()
     await this.questionInput.fill(question)
   }
 
   async fillAnswerInput(answer: string) {
+    await this.answerInput.clear()
     await this.answerInput.fill(answer)
   }
 
@@ -149,6 +151,7 @@ export class CreatePOM {
   }
 
   async fillGameName(gameName: string) {
+    await this.gameNameInput.clear()
     await this.gameNameInput.fill(gameName)
   }
 

--- a/service/app/src/app/create/components/createGameNavigation.tsx
+++ b/service/app/src/app/create/components/createGameNavigation.tsx
@@ -20,17 +20,25 @@ import { openSaveConfirmDialog } from "./dialog/saveConfirmDialog"
 export function CreateGameNavigation() {
   const router = useRouter()
 
-  const { gameName, questions, gameId, version, setGameName, reset } =
-    useCreateGameStore(
-      useShallow((state) => ({
-        gameName: state.gameName,
-        questions: state.questions,
-        gameId: state.gameId,
-        version: state.version,
-        setGameName: state.setGameName,
-        reset: state.reset,
-      })),
-    )
+  const {
+    gameName,
+    questions,
+    gameId,
+    version,
+    setGameName,
+    updateImageUrls,
+    reset,
+  } = useCreateGameStore(
+    useShallow((state) => ({
+      gameName: state.gameName,
+      questions: state.questions,
+      gameId: state.gameId,
+      version: state.version,
+      setGameName: state.setGameName,
+      updateImageUrls: state.updateImageUrls,
+      reset: state.reset,
+    })),
+  )
 
   const gameNameError = gameName.length > 30 || gameName.length < 1
 
@@ -54,8 +62,10 @@ export function CreateGameNavigation() {
     }
 
     try {
+      let result: { gameId: string; imageKeys: Map<number, string> }
+
       if (gameId && version !== null) {
-        await updateExistingGame(
+        result = await updateExistingGame(
           {
             gameName,
             questions,
@@ -68,7 +78,7 @@ export function CreateGameNavigation() {
           version,
         )
       } else {
-        await saveNewGame({
+        result = await saveNewGame({
           gameName,
           questions,
           selectedQuestionId: questions[0]?.id || "",
@@ -78,6 +88,7 @@ export function CreateGameNavigation() {
         })
       }
 
+      updateImageUrls(result.imageKeys)
       reset()
       router.push("/dashboard")
     } catch (error) {

--- a/service/app/src/app/create/store/types.ts
+++ b/service/app/src/app/create/store/types.ts
@@ -26,6 +26,7 @@ export interface CreateGameActions {
   uploadImage: (id: string, file: File, previewUrl: string) => void
   deleteImage: (id: string) => void
   updateQuestion: (id: string, updates: Partial<Question>) => void
+  updateImageUrls: (imageKeys: Map<number, string>) => void
   loadGameData: (gameId: string) => Promise<void>
   reset: () => void
 }

--- a/service/app/src/app/create/store/useCreateGameStore.tsx
+++ b/service/app/src/app/create/store/useCreateGameStore.tsx
@@ -123,6 +123,17 @@ const createGameStore = (initialGameName: string = "새 게임") =>
               }
             }
           }),
+        updateImageUrls: (imageKeys) =>
+          set((state) => {
+            imageKeys.forEach((key, questionOrder) => {
+              const questionIndex = state.questions.findIndex(
+                (q) => q.order === questionOrder,
+              )
+              if (questionIndex !== -1) {
+                state.questions[questionIndex].imageUrl = key
+              }
+            })
+          }),
         loadGameData: async (gameId) => {
           set((state) => {
             state.isLoading = true

--- a/service/app/src/app/layout.tsx
+++ b/service/app/src/app/layout.tsx
@@ -19,6 +19,13 @@ const pretendard = localFont({
   src: "../../public/PretendardVariable.woff2",
   weight: "400",
   variable: "--font-pretendard",
+  fallback: [
+    "system-ui",
+    "-apple-system",
+    "BlinkMacSystemFont",
+    "Segoe UI",
+    "sans-serif",
+  ],
 })
 
 const joyofSinging = localFont({

--- a/service/app/src/app/layout.tsx
+++ b/service/app/src/app/layout.tsx
@@ -24,10 +24,10 @@ const pretendard = localFont({
     "-apple-system",
     "BlinkMacSystemFont",
     "Segoe UI",
-    "sans-serif",
     "Apple Color Emoji",
     "Segoe UI Emoji",
     "Noto Color Emoji",
+    "sans-serif",
   ],
 })
 

--- a/service/app/src/app/layout.tsx
+++ b/service/app/src/app/layout.tsx
@@ -25,6 +25,9 @@ const pretendard = localFont({
     "BlinkMacSystemFont",
     "Segoe UI",
     "sans-serif",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Noto Color Emoji",
   ],
 })
 

--- a/service/app/src/entities/game/utils/gameSave.ts
+++ b/service/app/src/entities/game/utils/gameSave.ts
@@ -11,7 +11,9 @@ import { GameCreateRequest, GameUpdateRequest } from "../model"
 import { generateUniqueFileName } from "./fileValidation"
 import { uploadMultipleFilesToS3 } from "./s3Upload"
 
-export const saveNewGame = async (state: CreateGameState): Promise<UUID> => {
+export const saveNewGame = async (
+  state: CreateGameState,
+): Promise<{ gameId: UUID; imageKeys: Map<number, string> }> => {
   const questionsWithNewImages = state.questions.filter((q) => q.imageFile)
 
   const presignedRequest = questionsWithNewImages.map((question) => ({
@@ -71,16 +73,22 @@ export const saveNewGame = async (state: CreateGameState): Promise<UUID> => {
     )
   }
 
-  return gameId
+  return { gameId, imageKeys: imageUrlMap }
 }
 
 export const updateExistingGame = async (
   state: CreateGameState,
   gameId: UUID,
   version: number,
-): Promise<UUID> => {
+): Promise<{ gameId: UUID; imageKeys: Map<number, string> }> => {
   const questionsWithNewImages = state.questions.filter((q) => q.imageFile)
   const imageUrlMap: Map<number, string> = new Map()
+
+  state.questions.forEach((question) => {
+    if (question.imageUrl) {
+      imageUrlMap.set(question.order, question.imageUrl)
+    }
+  })
 
   if (questionsWithNewImages.length > 0) {
     const presignedRequest = questionsWithNewImages.map((question) => ({
@@ -130,7 +138,7 @@ export const updateExistingGame = async (
     gameThumbnailUrl: firstImageKey,
     questions: state.questions.map((question) => ({
       questionOrder: question.order,
-      imageUrl: imageUrlMap.get(question.order) || question.imageUrl,
+      imageUrl: imageUrlMap.get(question.order) || "",
       questionText: question.text.trim(),
       questionAnswer: question.answer.trim(),
     })),
@@ -146,5 +154,5 @@ export const updateExistingGame = async (
     throw new Error(response.error ?? "저장 중 오류가 발생했습니다.")
   }
 
-  return gameId
+  return { gameId, imageKeys: imageUrlMap }
 }


### PR DESCRIPTION
## 📝 설명

리뷰위크 때 windows / whale 사용자 분께서 이모지가 깨지는 문제가 있다는 말씀을 해 주셔서, fallback 폰트 등록으로 해당 문제를 해결하려 했습니다

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

joyofsinging 폰트는 꾸밈폰트고 사용처가 제한적이라 별도의 fallback이 필요없다고 판단해서 pretendard에만 추가했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 기본 폰트 대체 옵션이 확장되어 시스템 폰트와 이모지 폰트가 추가되었습니다.

* **New Features**
  * 게임 저장/수정 시 퍼스트파티 이미지 키가 함께 반환되어, 문항별 이미지 URL이 저장 흐름에 반영됩니다. 저장 후 이미지 연결이 보존됩니다.

* **Tests**
  * UI 검사 흐름이 모달 내부 콘텐츠를 대상으로 업데이트되어 표시를 보다 정확히 검증합니다.
  * 테스트 입력 동작이 입력 필드를 먼저 초기화한 뒤 채우도록 변경되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->