### PR TITLE
game update api 이슈 해결

### DIFF
--- a/service/app/src/entities/game/utils/fileValidation.ts
+++ b/service/app/src/entities/game/utils/fileValidation.ts
@@ -54,3 +54,10 @@ export const validateMultipleFiles = (files: File[]): FileValidationResult => {
   }
   return { isValid: true }
 }
+
+export const extractS3KeyFromUrl = (url: string): string => {
+  if (url.includes("games/")) {
+    return url.substring(url.indexOf("games/"))
+  }
+  return url
+}

--- a/service/app/src/entities/game/utils/gameSave.ts
+++ b/service/app/src/entities/game/utils/gameSave.ts
@@ -8,7 +8,7 @@ import {
   getPresignedUrlsForNewGame,
 } from "../api"
 import { GameCreateRequest, GameUpdateRequest } from "../model"
-import { generateUniqueFileName } from "./fileValidation"
+import { extractS3KeyFromUrl, generateUniqueFileName } from "./fileValidation"
 import { uploadMultipleFilesToS3 } from "./s3Upload"
 
 export const saveNewGame = async (
@@ -86,7 +86,8 @@ export const updateExistingGame = async (
 
   state.questions.forEach((question) => {
     if (question.imageUrl) {
-      imageUrlMap.set(question.order, question.imageUrl)
+      const key = extractS3KeyFromUrl(question.imageUrl)
+      imageUrlMap.set(question.order, key)
     }
   })
 
@@ -129,7 +130,9 @@ export const updateExistingGame = async (
   )
   const firstImageKey = firstQuestionWithImage
     ? imageUrlMap.get(firstQuestionWithImage.order) ||
-      firstQuestionWithImage.imageUrl
+      (firstQuestionWithImage.imageUrl
+        ? extractS3KeyFromUrl(firstQuestionWithImage.imageUrl)
+        : null)
     : null
 
   const gameUpdateRequest: GameUpdateRequest = {

--- a/service/app/src/entities/game/utils/index.ts
+++ b/service/app/src/entities/game/utils/index.ts
@@ -2,6 +2,7 @@ export { mapStatusToErrorResponse } from "./errorHandlers"
 export type { FileValidationResult } from "./fileValidation"
 export {
   ALLOWED_IMAGE_TYPES,
+  extractS3KeyFromUrl,
   generateUniqueFileName,
   MAX_FILE_SIZE,
   validateImageFile,


### PR DESCRIPTION
## 📝 설명

game update api를 호출할 때, imageUrl이 서버에서 GET해 온 game에 들어있는 값 그대로 들어가서 이후 imageurl이 중복되어 저장되는 문제 발생 -> url이 이상하다보니 프론트 화면에서 이미지 깨짐, url이 점점 길어지면 서버에서도 에러를 반환해서 프론트엔드 테스트도 실패
s3에서 발급받은 key만 서버로 보내게 수정해서 해결

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 게임 이미지 저장 및 처리 프로세스를 개선했습니다. 저장소 키 추출 로직을 최적화하여 기존 이미지 URL의 변환 및 처리 방식을 더욱 효율적으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->