### PR TITLE
stickyActionBar 컴포넌트 생성 및 /create 페이지 적용

### DIFF
--- a/service/app/src/app/create/components/createGameNavigation.tsx
+++ b/service/app/src/app/create/components/createGameNavigation.tsx
@@ -4,6 +4,7 @@ import {
   PrimaryBoxButton,
   SecondaryGhostIconButton,
 } from "@ject-5-fe/design/components/button"
+import { Navigation } from "@ject-5-fe/design/components/navigation"
 import * as TextField from "@ject-5-fe/design/components/textField"
 import { Cross } from "@ject-5-fe/design/icons"
 import { useRouter } from "next/navigation"
@@ -100,51 +101,54 @@ export function CreateGameNavigation() {
   }
 
   return (
-    <nav
-      className={`flex h-[110px] w-full items-center justify-between bg-background-primary px-10`}
-    >
-      <div className="flex w-[340px] bg-background-primary">
-        <TextField.Root
-          name="gameTitle"
-          state={gameNameError ? "error" : "default"}
-        >
-          <TextField.InputWrapper className="bg-background-interactive-input-primary">
-            <TextField.Input
-              placeholder="게임 이름 입력"
-              value={gameName}
-              onChange={(e) => setGameName(e.target.value)}
-            />
-          </TextField.InputWrapper>
-        </TextField.Root>
-      </div>
-
-      <div className="flex w-[420px] items-center justify-end gap-4 px-10">
-        <ThemeToggle data-testid="theme-toggle-button" />
-        <PrimaryBoxButton
-          size="sm"
-          disabled={!canSave}
-          onClick={() =>
-            openSaveConfirmDialog({
-              onConfirm: handleSaveGame,
-            })
-          }
-        >
-          게임 저장
-        </PrimaryBoxButton>
-        <SecondaryGhostIconButton
-          onClick={() =>
-            openExitConfirmDialog({
-              onConfirm: () => {
-                reset()
-                router.push("/")
-              },
-            })
-          }
-          data-testid="cross-button"
-        >
-          <Cross />
-        </SecondaryGhostIconButton>
-      </div>
-    </nav>
+    <Navigation
+      leftContent={
+        <div className="flex w-[340px] items-center px-16">
+          <TextField.Root
+            name="gameTitle"
+            className="w-full"
+            state={gameNameError ? "error" : "default"}
+          >
+            <TextField.InputWrapper className="bg-transparent shadow-none">
+              <TextField.Input
+                placeholder="게임 이름 입력"
+                value={gameName}
+                onChange={(e) => setGameName(e.target.value)}
+              />
+            </TextField.InputWrapper>
+          </TextField.Root>
+        </div>
+      }
+      centerContent={null}
+      rightContent={
+        <>
+          <ThemeToggle data-testid="theme-toggle-button" />
+          <PrimaryBoxButton
+            size="sm"
+            disabled={!canSave}
+            onClick={() =>
+              openSaveConfirmDialog({
+                onConfirm: handleSaveGame,
+              })
+            }
+          >
+            게임 저장
+          </PrimaryBoxButton>
+          <SecondaryGhostIconButton
+            onClick={() =>
+              openExitConfirmDialog({
+                onConfirm: () => {
+                  reset()
+                  router.push("/")
+                },
+              })
+            }
+            data-testid="cross-button"
+          >
+            <Cross />
+          </SecondaryGhostIconButton>
+        </>
+      }
+    ></Navigation>
   )
 }

--- a/service/app/src/app/create/components/questionList.tsx
+++ b/service/app/src/app/create/components/questionList.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { PrimaryBoxButton } from "@ject-5-fe/design/components/button"
 import { Question } from "@ject-5-fe/design/components/question"
+import { StickyActionBar } from "@ject-5-fe/design/components/stickyActionBar"
 import Image from "next/image"
 import { useShallow } from "zustand/react/shallow"
 
@@ -13,6 +15,7 @@ export function QuestionList() {
     setSelectedQuestionId,
     deleteQuestion,
     moveQuestion,
+    addQuestion,
   } = useCreateGameStore(
     useShallow((state) => ({
       questions: state.questions,
@@ -20,57 +23,71 @@ export function QuestionList() {
       setSelectedQuestionId: state.setSelectedQuestionId,
       deleteQuestion: state.deleteQuestion,
       moveQuestion: state.moveQuestion,
+      addQuestion: state.addQuestion,
     })),
   )
 
   return (
     <div
-      className="flex w-[420px] flex-col items-start overflow-y-auto bg-background-tertiary px-[32px] py-[16px]"
+      className="flex h-full min-h-0 w-[420px] flex-col bg-background-tertiary"
       data-testid="question-list"
     >
-      {questions.map((question, index) => {
-        const isSelected = selectedQuestionId === question.id
-        const questionError =
-          question.text.length > 50 || question.text.length < 1
+      <div className="flex-1 overflow-y-auto px-[32px] py-[16px] pb-32">
+        {questions.map((question, index) => {
+          const isSelected = selectedQuestionId === question.id
+          const questionError =
+            question.text.length > 50 || question.text.length < 1
 
-        return (
-          <div key={question.id}>
-            <Question
-              index={index + 1}
-              state={
-                isSelected ? "selected" : questionError ? "error" : "default"
-              }
-              onClick={() => setSelectedQuestionId(question.id)}
-            >
-              <Question.Title>
-                {question.text || "질문을 입력해주세요"}
-              </Question.Title>
+          return (
+            <div key={question.id} className="mb-24 last:mb-0">
+              <Question
+                index={index + 1}
+                state={
+                  isSelected ? "selected" : questionError ? "error" : "default"
+                }
+                onClick={() => setSelectedQuestionId(question.id)}
+              >
+                <Question.Title>
+                  {question.text || "질문을 입력해주세요"}
+                </Question.Title>
 
-              <Question.Image>
-                {(question.imageUrl || question.previewImageUrl) && (
-                  <Image
-                    src={question.imageUrl || question.previewImageUrl || ""}
-                    alt="질문 이미지"
-                    width={78}
-                    height={78}
-                    className="size-[78px] rounded-[7px] object-cover"
-                  />
-                )}
-              </Question.Image>
+                <Question.Image>
+                  {(question.imageUrl || question.previewImageUrl) && (
+                    <Image
+                      src={question.imageUrl || question.previewImageUrl || ""}
+                      alt="질문 이미지"
+                      width={78}
+                      height={78}
+                      className="size-[78px] rounded-[7px] object-cover"
+                    />
+                  )}
+                </Question.Image>
 
-              <Question.DeleteButton
-                onDelete={() => deleteQuestion(question.id)}
-                canDelete={questions.length > 1}
-              />
+                <Question.DeleteButton
+                  onDelete={() => deleteQuestion(question.id)}
+                  canDelete={questions.length > 1}
+                />
 
-              <Question.MoveButtons
-                onMoveUp={() => moveQuestion(question.id, "up")}
-                onMoveDown={() => moveQuestion(question.id, "down")}
-              />
-            </Question>
-          </div>
-        )
-      })}
+                <Question.MoveButtons
+                  onMoveUp={() => moveQuestion(question.id, "up")}
+                  onMoveDown={() => moveQuestion(question.id, "down")}
+                />
+              </Question>
+            </div>
+          )
+        })}
+      </div>
+
+      <StickyActionBar
+        position="sticky"
+        edge="bottom"
+        className="mt-auto px-[32px] pb-[16px]"
+        contentClassName="w-full"
+      >
+        <PrimaryBoxButton size="xl" onClick={addQuestion} className="w-full">
+          문제 추가하기
+        </PrimaryBoxButton>
+      </StickyActionBar>
     </div>
   )
 }

--- a/shared/design/src/components/stickyActionBar/index.tsx
+++ b/shared/design/src/components/stickyActionBar/index.tsx
@@ -1,0 +1,118 @@
+import { type ComponentPropsWithoutRef, type CSSProperties } from "react"
+
+import { cn } from "../../utils/cn"
+
+type StickyActionBarPosition = "static" | "sticky" | "fixed"
+type StickyActionBarEdge = "top" | "bottom"
+type StickyActionBarAlign = "start" | "center" | "end" | "space-between"
+
+export interface StickyActionBarProps extends ComponentPropsWithoutRef<"div"> {
+  /**
+   * 원하는 포지셔닝 방식을 선택합니다. 기본값은 `sticky`입니다.
+   */
+  position?: StickyActionBarPosition
+  /**
+   * 고정될 방향을 결정합니다. 기본값은 `bottom`입니다.
+   */
+  edge?: StickyActionBarEdge
+  /**
+   * `sticky` 또는 `fixed` 상태일 때의 오프셋 값입니다. 숫자는 px 단위로 처리됩니다.
+   */
+  offset?: number | string
+  /**
+   * 내부 콘텐츠 정렬 방식입니다. 기본값은 `center`입니다.
+   */
+  align?: StickyActionBarAlign
+  /**
+   * 내부 컨텐츠 영역에 추가 클래스를 지정합니다.
+   */
+  contentClassName?: string
+  /**
+   * 내부 컨텐츠 영역의 최대 너비를 제한합니다.
+   */
+  maxWidth?: number | string
+  /**
+   * 컨테이너의 라운드를 적용할지 여부입니다.
+   */
+  rounded?: boolean
+}
+
+const justifyClassMap: Record<StickyActionBarAlign, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  "space-between": "justify-between",
+}
+
+export const StickyActionBar = ({
+  children,
+  className,
+  style,
+  position = "sticky",
+  edge = "bottom",
+  offset = 0,
+  align = "center",
+  contentClassName,
+  maxWidth,
+  rounded = false,
+  ...rest
+}: StickyActionBarProps) => {
+  const offsetValue =
+    position === "static"
+      ? undefined
+      : typeof offset === "number"
+        ? `${offset}px`
+        : offset
+
+  const positionalClass =
+    position === "fixed"
+      ? "fixed inset-x-0"
+      : position === "sticky"
+        ? "sticky"
+        : undefined
+
+  const radiusClass = rounded ? "rounded-12" : undefined
+
+  const shadowClass = "bg-none bg-transparent"
+
+  const positionalStyle: CSSProperties =
+    position === "static" || !offsetValue
+      ? {}
+      : edge === "bottom"
+        ? { bottom: offsetValue }
+        : { top: offsetValue }
+
+  const innerStyle: CSSProperties | undefined =
+    maxWidth !== undefined
+      ? {
+          maxWidth: typeof maxWidth === "number" ? `${maxWidth}px` : maxWidth,
+        }
+      : undefined
+
+  return (
+    <div
+      className={cn(
+        "z-40 flex w-full justify-center px-24 py-12",
+        positionalClass,
+        shadowClass,
+        radiusClass,
+        className,
+      )}
+      style={{ ...positionalStyle, ...style }}
+      {...rest}
+    >
+      <div
+        className={cn(
+          "flex w-full items-center gap-16",
+          justifyClassMap[align],
+          contentClassName,
+        )}
+        style={innerStyle}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+StickyActionBar.displayName = "StickyActionBar"

--- a/shared/design/src/stories/stickyActionBar.stories.tsx
+++ b/shared/design/src/stories/stickyActionBar.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { PrimaryBoxButton } from "../components/button"
+import { StickyActionBar } from "../components/stickyActionBar"
+
+const meta = {
+  title: "Components/StickyActionBar",
+  component: StickyActionBar,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "스크롤이 길어도 주요 액션을 화면 하단에 고정해 노출할 수 있는 레이아웃 래퍼입니다.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof StickyActionBar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ViewportFixedAction: Story = {
+  render: () => (
+    <div className="min-h-screen w-full bg-background-tertiary">
+      <div className="mx-auto flex min-h-screen w-full max-w-[720px] flex-col bg-background-primary">
+        <header className="sticky top-0 z-30 border-b border-border-interactive-secondary bg-background-primary px-32 py-24">
+          <h1 className="typography-heading-xl-semibold text-text-primary">
+            문제 편집 화면
+          </h1>
+          <p className="typography-body-md-regular mt-12 text-text-secondary">
+            스크롤을 내려도 하단의 “문제 추가하기” 버튼이 고정되어 있는 모습을
+            확인하세요.
+          </p>
+        </header>
+
+        <main className="flex-1 space-y-20 px-32 pb-[160px] pt-24">
+          {[...Array(24)].map((_, index) => (
+            <article
+              key={index}
+              className="rounded-12 border border-border-interactive-tertiary bg-background-secondary p-24 shadow-[0px_8px_24px_rgba(15,23,42,0.1)]"
+            >
+              <h2 className="typography-heading-md-semibold text-text-primary">
+                섹션 {index + 1}
+              </h2>
+              <p className="typography-body-sm-regular mt-12 text-text-secondary">
+                실제 화면에서 긴 설명, 입력 폼, 미디어 블록 등이 들어갈 수 있는
+                영역을 가정한 더미 컨텐츠입니다.
+              </p>
+            </article>
+          ))}
+        </main>
+      </div>
+
+      <StickyActionBar
+        position="fixed"
+        edge="bottom"
+        className=""
+        maxWidth={720}
+      >
+        <PrimaryBoxButton size="xl" className="w-full">
+          문제 추가하기
+        </PrimaryBoxButton>
+      </StickyActionBar>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "전체 뷰포트 기준으로 StickyActionBar를 고정한 예시입니다. 메인 컨텐츠가 스크롤되더라도 액션 버튼이 항상 하단에 노출됩니다.",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 📝 설명
- 컴포넌트를 제작하고 /create페이지에 적용
## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문제 목록 하단에 고정된 "문제 추가하기" 액션 바 추가 — 스크롤 중에도 항상 표시
  * 게임 생성 화면의 네비게이션 레이아웃 개선 — 게임명 입력 필드와 테마 토글·저장·종료 버튼 배치 최적화
* **테스트**
  * 대시보드 게임 카드 상호작용을 위한 테스트 헬퍼 및 테스트 식별자 추가로 E2E 테스트 접근성 개선
* **문서(스토리)**
  * 고정 액션 바 컴포넌트의 스토리북 예제 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->