### PR TITLE
게임페이지 레이아웃 조정 및 문제 이동 버튼 디자인 갱신

### DIFF
--- a/service/app/src/app/game/[gameId]/play/__tests__/game-play.spec.ts
+++ b/service/app/src/app/game/[gameId]/play/__tests__/game-play.spec.ts
@@ -20,19 +20,21 @@ test.describe("게임 진행 - 두 번째 문제 플로우", () => {
     pageObj = new GamePlayPOM(page)
   })
 
-  test("1번 문제: 이전 버튼은 안 보이고 다음 버튼은 보여야 한다", async () => {
-    await expect(pageObj.prevQuestionButton).not.toBeVisible()
-    await expect(pageObj.nextQuestionButton).toBeVisible()
+  test("1번 문제: 이전 버튼은 비활성화되고 다음 버튼은 활성화되어야 한다", async () => {
+    await expect(pageObj.prevQuestionButton).toBeDisabled()
+    await expect(pageObj.nextQuestionButton).toBeEnabled()
 
     const progress = await pageObj.getProgressValue()
     expect(progress).not.toBeNull()
   })
 
-  test("2번 문제: 이전/다음 버튼이 모두 보여야 한다", async ({ page }) => {
+  test("2번 문제: 이전/다음 버튼이 모두 활성화되어야 한다", async ({
+    page,
+  }) => {
     await pageObj.goToNextQuestion()
     await expect(page).toHaveURL(/\?q=2/)
-    await expect(pageObj.prevQuestionButton).toBeVisible()
-    await expect(pageObj.nextQuestionButton).toBeVisible()
+    await expect(pageObj.prevQuestionButton).toBeEnabled()
+    await expect(pageObj.nextQuestionButton).toBeEnabled()
   })
 
   test("홈 로고 클릭 시 나가기 다이얼로그가 뜨고, '아니요' 클릭 시 페이지에 머문다", async ({

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -7,11 +7,23 @@ import { useState } from "react"
 
 import type { GameQuestion } from "@/entities/game/model"
 
+import { QuestionNavigationButton } from "./questionNavigationButton"
+
 interface GamePlayContentProps {
   currentQuestion: GameQuestion
+  currentRound: number
+  totalRounds: number
+  onPrevQuestion: () => void
+  onNextQuestion: () => void
 }
 
-export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
+export const GamePlayContent = ({
+  currentQuestion,
+  currentRound,
+  totalRounds,
+  onPrevQuestion,
+  onNextQuestion,
+}: GamePlayContentProps) => {
   const [showAnswer, setShowAnswer] = useState(false)
 
   return (
@@ -36,22 +48,36 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
         </div>
       )}
 
-      {showAnswer ? (
-        <SecondaryOutlineBoxButton
-          size="lg"
-          onClick={() => setShowAnswer(false)}
-        >
-          {currentQuestion?.questionAnswer}
-        </SecondaryOutlineBoxButton>
-      ) : (
-        <PrimaryBoxButton
-          size="2xl"
-          _style="solid"
-          onClick={() => setShowAnswer(true)}
-        >
-          정답 보기
-        </PrimaryBoxButton>
-      )}
+      <div className="flex items-center justify-center gap-6">
+        <QuestionNavigationButton
+          direction="prev"
+          onClick={onPrevQuestion}
+          disabled={currentRound <= 1}
+        />
+
+        {showAnswer ? (
+          <SecondaryOutlineBoxButton
+            size="lg"
+            onClick={() => setShowAnswer(false)}
+          >
+            {currentQuestion?.questionAnswer}
+          </SecondaryOutlineBoxButton>
+        ) : (
+          <PrimaryBoxButton
+            size="2xl"
+            _style="solid"
+            onClick={() => setShowAnswer(true)}
+          >
+            정답 보기
+          </PrimaryBoxButton>
+        )}
+
+        <QuestionNavigationButton
+          direction="next"
+          onClick={onNextQuestion}
+          disabled={currentRound >= totalRounds}
+        />
+      </div>
     </div>
   )
 }

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -15,18 +15,19 @@ export const GamePlayContent = ({ currentQuestion }: GamePlayContentProps) => {
   const [showAnswer, setShowAnswer] = useState(false)
 
   return (
-    <div className="flex w-full flex-1 flex-col items-center justify-center">
-      <h1 className="typography-heading-4xl-bold mb-[118px] max-w-[1080px] text-center text-text-primary">
+    <div className="flex w-full flex-1 flex-col items-center justify-center gap-[68px]">
+      <h1 className="typography-heading-4xl-bold max-w-[1080px] text-center text-text-primary">
         {currentQuestion.questionText}
       </h1>
 
       {currentQuestion?.imageUrl && (
-        <div className="relative mb-[85px] min-h-[459px] w-[727px] overflow-hidden rounded-[10px]">
+        <div className="relative max-h-[40vh] w-full overflow-hidden rounded-[10px]">
           <Image
             src={currentQuestion.imageUrl}
             alt="문제 이미지"
-            className="size-full rounded-[10px] object-contain transition-opacity duration-300"
-            fill
+            className="h-auto max-h-[40vh] w-full rounded-[10px] object-contain transition-opacity duration-300"
+            width={727}
+            height={459}
             placeholder="blur"
             blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNzI3IiBoZWlnaHQ9IjQ1OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZTVlN2ViIi8+PC9zdmc+"
             loading="eager"

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
@@ -42,13 +42,13 @@ export const GamePlayHeader = ({
 
       <div className="flex flex-1 items-center justify-center">
         <Progress
-          className="h-[25px] w-[1080px]"
+          className="h-[25px] w-full"
           value={totalRounds > 0 ? (currentRound / totalRounds) * 100 : 0}
           max={100}
         />
       </div>
 
-      <div className="flex w-[420px] flex-col items-end justify-center gap-2.5">
+      <div className="flex w-[420px] flex-col items-end justify-center gap-16">
         <div className="flex items-center justify-end gap-4 px-10">
           <ThemeToggle />
 

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayNavigation.tsx
@@ -1,7 +1,4 @@
-import {
-  PrimaryBoxButton,
-  SecondaryPlainIconButton,
-} from "@ject-5-fe/design/components/button"
+import { SecondaryPlainIconButton } from "@ject-5-fe/design/components/button"
 import { Progress } from "@ject-5-fe/design/components/progress"
 import { Cross } from "@ject-5-fe/design/icons"
 import Image from "next/image"
@@ -11,16 +8,12 @@ import { ThemeToggle } from "@/shared/themeToggleButton"
 interface GamePlayHeaderProps {
   currentRound: number
   totalRounds: number
-  onPrevQuestion: () => void
-  onNextQuestion: () => void
   onExit: () => void
 }
 
 export const GamePlayHeader = ({
   currentRound,
   totalRounds,
-  onPrevQuestion,
-  onNextQuestion,
   onExit,
 }: GamePlayHeaderProps) => {
   return (
@@ -48,19 +41,9 @@ export const GamePlayHeader = ({
         />
       </div>
 
-      <div className="flex w-[420px] flex-col items-end justify-center gap-16">
-        <div className="flex items-center justify-end gap-4 px-10">
+      <div className="flex w-[420px] flex-col items-end justify-center">
+        <div className="flex items-center justify-end gap-16 px-10">
           <ThemeToggle />
-
-          {currentRound > 1 && (
-            <PrimaryBoxButton size="sm" _style="solid" onClick={onPrevQuestion}>
-              이전 문제
-            </PrimaryBoxButton>
-          )}
-
-          <PrimaryBoxButton size="sm" _style="solid" onClick={onNextQuestion}>
-            다음 문제
-          </PrimaryBoxButton>
 
           <SecondaryPlainIconButton
             size="lg"

--- a/service/app/src/app/game/[gameId]/play/components/questionNavigationButton.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/questionNavigationButton.tsx
@@ -1,0 +1,36 @@
+import { SecondaryGhostIconButton } from "@ject-5-fe/design/components/button"
+import { ArrowLeft, ArrowRight } from "@ject-5-fe/design/icons"
+import { cn } from "@ject-5-fe/design/utils/cn"
+
+interface QuestionNavigationButtonProps {
+  direction: "prev" | "next"
+  onClick: () => void
+  disabled?: boolean
+  className?: string
+}
+
+export const QuestionNavigationButton = ({
+  direction,
+  onClick,
+  disabled = false,
+  className,
+}: QuestionNavigationButtonProps) => {
+  return (
+    <SecondaryGhostIconButton
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "size-92 rounded-full bg-background-thumbnail-tertiary",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+      aria-label={direction === "prev" ? "이전 문제" : "다음 문제"}
+    >
+      {direction === "prev" ? (
+        <ArrowLeft size={40} />
+      ) : (
+        <ArrowRight size={40} />
+      )}
+    </SecondaryGhostIconButton>
+  )
+}

--- a/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
@@ -19,13 +19,13 @@ export const ScoreboardSidebar = ({
   const clampScore = (value: number) => Math.max(-100, Math.min(100, value))
 
   return (
-    <div className="flex max-h-[940px] w-[400px] min-w-[400px] flex-col rounded-[20px] bg-background-tertiary">
-      <div className="relative flex items-center justify-center py-6">
-        <span className="typography-heading-sm-bold text-text-primary">
+    <div className="flex max-h-[940px] w-[400px] min-w-[400px] flex-col rounded-[20px] bg-background-tertiary px-24">
+      <div className="relative flex items-center justify-center py-20">
+        <span className="typography-heading-sm-bold w-full text-center text-text-primary">
           점수판
         </span>
         <PrimarySolidIconButton
-          className="absolute right-9 top-4"
+          className="right-0 top-16"
           onClick={() => setIsSidebarOpen(!isSidebarOpen)}
           aria-label="점수판 토글"
         >
@@ -33,7 +33,7 @@ export const ScoreboardSidebar = ({
         </PrimarySolidIconButton>
       </div>
       {isSidebarOpen && (
-        <div className="flex max-h-[850px] flex-1 flex-col items-center gap-6 overflow-y-scroll px-[25px] py-6">
+        <div className="flex max-h-[850px] flex-1 flex-col items-center gap-24 overflow-y-scroll pb-48">
           {teams.map((team) => (
             <PlayerStatus
               key={team.id}

--- a/service/app/src/app/game/[gameId]/play/page.tsx
+++ b/service/app/src/app/game/[gameId]/play/page.tsx
@@ -47,11 +47,6 @@ const ScoreboardGame = () => {
       <GamePlayHeader
         currentRound={currentRound}
         totalRounds={totalRounds}
-        onPrevQuestion={() => {
-          if (currentRound <= 1) return
-          setSearchParams({ q: (currentRound - 1).toString() })
-        }}
-        onNextQuestion={handleNextQuestion}
         onExit={() =>
           openExitConfirmDialog({
             onConfirm: () => router.push("/"),
@@ -62,7 +57,16 @@ const ScoreboardGame = () => {
         <ScoreboardSidebar teams={teams} onUpdateTeamScore={updateTeamScore} />
       </div>
       <div>
-        <GamePlayContent currentQuestion={currentQuestion} />
+        <GamePlayContent
+          currentQuestion={currentQuestion}
+          currentRound={currentRound}
+          totalRounds={totalRounds}
+          onPrevQuestion={() => {
+            if (currentRound <= 1) return
+            setSearchParams({ q: (currentRound - 1).toString() })
+          }}
+          onNextQuestion={handleNextQuestion}
+        />
       </div>
     </>
   )

--- a/service/app/src/app/game/[gameId]/play/page.tsx
+++ b/service/app/src/app/game/[gameId]/play/page.tsx
@@ -58,7 +58,7 @@ const ScoreboardGame = () => {
           })
         }
       />
-      <div className="absolute left-[20px] top-[110px]">
+      <div className="absolute left-[20px] top-[110px] z-10">
         <ScoreboardSidebar teams={teams} onUpdateTeamScore={updateTeamScore} />
       </div>
       <div>

--- a/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
+++ b/service/app/src/app/game/[gameId]/setup/__tests__/gameSetupPOM.ts
@@ -100,6 +100,6 @@ export class GameSetupPOM {
   async startGame(): Promise<void> {
     await expect(this.startButton).toBeEnabled()
     await this.startButton.click()
-    await expect(this.page).toHaveURL(/\/game\/\d+\/play/)
+    await this.page.waitForURL(/\/game\/\d+\/play/)
   }
 }

--- a/shared/design/src/components/playerStatus/index.tsx
+++ b/shared/design/src/components/playerStatus/index.tsx
@@ -22,7 +22,7 @@ export const PlayerStatus = ({
   return (
     <div
       className={cn(
-        "flex min-h-[40px] w-[310px] items-center justify-center rounded-12 bg-background-primary",
+        "flex min-h-[40px] w-full items-center justify-center rounded-12 bg-background-primary px-20",
         className,
       )}
       role="group"
@@ -36,7 +36,7 @@ export const PlayerStatus = ({
         </h3>
 
         {scoreView && (
-          <div className="flex h-[40px] w-[138px] items-center justify-between gap-8">
+          <div className="flex h-[40px] w-[138px] items-center justify-between gap-16">
             <SecondaryPlainIconButton
               size="lg"
               onClick={onScoreDecrease}

--- a/shared/design/src/icons/arrowLeft.tsx
+++ b/shared/design/src/icons/arrowLeft.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, type Ref, type SVGProps } from "react"
+
+const ArrowLeft = (
+  {
+    size = 24,
+    ...props
+  }: SVGProps<SVGSVGElement> & {
+    size?: number | string
+  },
+  ref: Ref<SVGSVGElement>,
+) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 46 37"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    ref={ref}
+    {...props}
+  >
+    <path
+      d="M43 21.0098C44.3807 21.0098 45.5 19.8905 45.5 18.5098C45.5 17.1291 44.3807 16.0098 43 16.0098L43 18.5098L43 21.0098ZM1.23223 16.742C0.255924 17.7183 0.255924 19.3012 1.23223 20.2775L17.1421 36.1874C18.1184 37.1637 19.7014 37.1637 20.6777 36.1874C21.654 35.2111 21.654 33.6282 20.6777 32.6519L6.53553 18.5098L20.6777 4.36763C21.654 3.39132 21.654 1.8084 20.6777 0.832094C19.7014 -0.144217 18.1184 -0.144217 17.1421 0.832094L1.23223 16.742ZM43 18.5098L43 16.0098L3 16.0098L3 18.5098L3 21.0098L43 21.0098L43 18.5098Z"
+      fill="#51A2FF"
+    />
+  </svg>
+)
+
+const ForwardRef = forwardRef(ArrowLeft)
+export default ForwardRef

--- a/shared/design/src/icons/arrowRight.tsx
+++ b/shared/design/src/icons/arrowRight.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, type Ref, type SVGProps } from "react"
+
+const ArrowRight = (
+  {
+    size = 24,
+    ...props
+  }: SVGProps<SVGSVGElement> & {
+    size?: number | string
+  },
+  ref: Ref<SVGSVGElement>,
+) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 46 37"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    ref={ref}
+    {...props}
+  >
+    <path
+      d="M3 16C1.61929 16 0.5 17.1193 0.5 18.5C0.5 19.8807 1.61929 21 3 21V18.5V16ZM44.7678 20.2678C45.7441 19.2915 45.7441 17.7085 44.7678 16.7322L28.8579 0.82233C27.8816 -0.15398 26.2986 -0.15398 25.3223 0.82233C24.346 1.79864 24.346 3.38155 25.3223 4.35786L39.4645 18.5L25.3223 32.6421C24.346 33.6184 24.346 35.2014 25.3223 36.1777C26.2986 37.154 27.8816 37.154 28.8579 36.1777L44.7678 20.2678ZM3 18.5V21H43V18.5V16H3V18.5Z"
+      fill="#51A2FF"
+    />
+  </svg>
+)
+
+const ForwardRef = forwardRef(ArrowRight)
+export default ForwardRef

--- a/shared/design/src/icons/index.ts
+++ b/shared/design/src/icons/index.ts
@@ -1,5 +1,7 @@
 export { default as Add } from "./add"
 export { default as Arrow } from "./arrow"
+export { default as ArrowLeft } from "./arrowLeft"
+export { default as ArrowRight } from "./arrowRight"
 export { default as Copy } from "./copy"
 export { default as Cross } from "./cross"
 export { default as Edit } from "./edit"


### PR DESCRIPTION
## 📝 설명

- 게임 진행 페이지의 전체적인 레이아웃을 조정
- scoreboard에서 사용하는 디자인 토큰 최신화
- '다음 문제', '이전 문제' 버튼 위치 figma와 동기화
- arrow 아이콘 생성
- arrow 아이콘을 사용하는 questionNavigationButton 컴포넌트 생성

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문제 이전/다음 네비게이션 버튼 추가로 질문 간 이동 가능
  * 좌/우 화살표 아이콘 추가 및 아이콘 재사용성 향상

* **Style**
  * 게임 플레이 레이아웃 및 이미지 반응형 개선
  * 진행 바가 전체 너비를 사용하도록 조정
  * 스코어보드 사이드바 및 플레이어 상태의 간격·정렬 개선

* **Tests**
  * 네비게이션 버튼 활성화 상태를 검증하도록 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->