### PR TITLE
정답 공개 상태가 유지되었던 문제 해결

### DIFF
--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -3,7 +3,7 @@ import {
   SecondaryOutlineBoxButton,
 } from "@ject-5-fe/design/components/button"
 import Image from "next/image"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import type { GameQuestion } from "@/entities/game/model"
 
@@ -25,6 +25,10 @@ export const GamePlayContent = ({
   onNextQuestion,
 }: GamePlayContentProps) => {
   const [showAnswer, setShowAnswer] = useState(false)
+
+  useEffect(() => {
+    setShowAnswer(false)
+  }, [currentRound])
 
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-center gap-[68px]">


### PR DESCRIPTION
## 📝 설명

- 게임 진행 페이지에서, 정답 공개 상태가 유지되는 문제 해결 ('정답 공개'를 누른 상태로 다음 문제로 넘어가면 정답이 공개된 상태가 유지됨)

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 새 라운드가 시작될 때 이전 라운드의 답변 표시가 자동으로 초기화되어 보다 일관된 게임 플레이 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->