### PR TITLE
게임 플레이 페이지 answerToggle 스타일 조정

### DIFF
--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -1,7 +1,3 @@
-import {
-  PrimaryBoxButton,
-  SecondaryOutlineBoxButton,
-} from "@ject-5-fe/design/components/button"
 import Image from "next/image"
 import { useEffect, useState } from "react"
 
@@ -60,20 +56,19 @@ export const GamePlayContent = ({
         />
 
         {showAnswer ? (
-          <SecondaryOutlineBoxButton
-            size="lg"
+          <div
             onClick={() => setShowAnswer(false)}
+            className="typography-heading-3xl-semibold inline-flex w-[572px] cursor-pointer flex-row items-center justify-center gap-12 rounded-12 border-[3px] border-border-interactive-secondary bg-background-interactive-inverse px-32 py-12 text-text-interactive-secondary hover:bg-background-interactive-secondary-hovered active:border-none active:bg-background-interactive-secondary-pressed"
           >
             {currentQuestion?.questionAnswer}
-          </SecondaryOutlineBoxButton>
+          </div>
         ) : (
-          <PrimaryBoxButton
-            size="2xl"
-            _style="solid"
+          <div
             onClick={() => setShowAnswer(true)}
+            className="typography-heading-3xl-semibold inline-flex w-[572px] cursor-pointer flex-row items-center justify-center gap-8 rounded-12 border-[3px] border-transparent bg-background-interactive-primary px-32 py-12 text-text-interactive-inverse hover:bg-background-interactive-primary-hovered active:border-transparent active:bg-background-interactive-primary-pressed"
           >
             정답 보기
-          </PrimaryBoxButton>
+          </div>
         )}
 
         <QuestionNavigationButton


### PR DESCRIPTION
## 📝 설명

- 이전에 게임 진행 페이지의 정답 토글이 고정된 높이를 가지고 있어서, 텍스트의 길이가 길 경우 border 밖으로 텍스트가 빠져나가는 현상 발생, 해당 문제 해결
- 공통컴포넌트 버튼 기반 -> 일반 div 기반으로 변경

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터**
  - 게임 플레이 화면의 답변 버튼 인터페이스 구조를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->