### PR TITLE
타이포그래피, border width 토큰 추가

### DIFF
--- a/service/app/src/app/_components/HeroSection.tsx
+++ b/service/app/src/app/_components/HeroSection.tsx
@@ -9,7 +9,7 @@ export const HeroSection = ({ className = "" }: HeroSectionProps) => {
       aria-label="메인 히어로 섹션"
     >
       <h1
-        className="typography-heading-2xl-bold text-center font-joyofsinging text-text-interactive-secondary"
+        className="typography-heading-2xl-extrabold text-center font-joyofsinging text-text-interactive-secondary"
         data-testid="hero-title"
       >
         모두가 가볍게 즐길 수 있는

--- a/service/app/src/app/create/loading.tsx
+++ b/service/app/src/app/create/loading.tsx
@@ -10,7 +10,7 @@ export default function CreateGamePageSkeleton() {
         height={100}
         unoptimized
       />
-      <p className="typography-heading-md-bold">
+      <p className="typography-heading-md-extrabold">
         페이지를 준비하고 있습니다...
       </p>
     </div>

--- a/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/gamePlayContent.tsx
@@ -29,7 +29,7 @@ export const GamePlayContent = ({
 
   return (
     <div className="flex w-full flex-1 flex-col items-center justify-center gap-[68px]">
-      <h1 className="typography-heading-4xl-bold max-w-[1080px] text-center text-text-primary">
+      <h1 className="typography-heading-4xl-extrabold max-w-[1080px] text-center text-text-primary">
         {currentQuestion.questionText}
       </h1>
 

--- a/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
+++ b/service/app/src/app/game/[gameId]/play/components/scoreboardSidebar.tsx
@@ -23,7 +23,7 @@ export const ScoreboardSidebar = ({
   return (
     <div className="flex max-h-[940px] w-[400px] min-w-[400px] flex-col rounded-[20px] bg-background-tertiary px-24">
       <div className="relative flex items-center justify-center py-20">
-        <span className="typography-heading-sm-bold w-full text-center text-text-primary">
+        <span className="typography-heading-sm-extrabold w-full text-center text-text-primary">
           점수판
         </span>
         <PrimarySolidIconButton

--- a/service/app/src/app/game/[gameId]/result/components/gameResultContent.tsx
+++ b/service/app/src/app/game/[gameId]/result/components/gameResultContent.tsx
@@ -32,10 +32,10 @@ export const GameResultContent = ({
             key={team.id}
             className="flex items-center justify-center gap-[30px] rounded-[10px] bg-gray-100 px-[110px] py-[18px]"
           >
-            <span className="text-[57px] font-bold text-blue-700">
+            <span className="text-[57px] font-extrabold text-blue-700">
               {team.name}
             </span>
-            <span className="text-[57px] font-bold text-blue-400">
+            <span className="text-[57px] font-extrabold text-blue-400">
               {scores[team.id]}점
             </span>
           </div>

--- a/service/app/src/app/mobile/page.tsx
+++ b/service/app/src/app/mobile/page.tsx
@@ -11,7 +11,7 @@ export default function MobilePage() {
           height={60}
           priority
         />
-        <p className="typography-heading-md-bold w-full whitespace-nowrap text-center text-text-primary">
+        <p className="typography-heading-md-extrabold w-full whitespace-nowrap text-center text-text-primary">
           원활한 참여를 위해
           <br />
           <span className="text-text-interactive-primary">웹 브라우저</span>로

--- a/service/app/src/entities/game/ui/GameCard/gameCard.tsx
+++ b/service/app/src/entities/game/ui/GameCard/gameCard.tsx
@@ -114,7 +114,7 @@ export const Description = ({ children, className }: DescriptionProps) => {
   return (
     <p
       className={cn(
-        "typography-body-lg-bold line-clamp-2 w-full break-keep text-text-secondary",
+        "typography-body-lg-extrabold line-clamp-2 w-full break-keep text-text-primary",
         className,
       )}
       data-testid="gamecard-description"

--- a/service/app/src/entities/game/ui/gameCreate.tsx
+++ b/service/app/src/entities/game/ui/gameCreate.tsx
@@ -20,7 +20,7 @@ export const GameCreate = ({ className = "" }: GameCreateProps) => {
         className="size-full object-contain"
       />
 
-      <h3 className="typography-heading-sm-bold text-center text-text-primary">
+      <h3 className="typography-heading-sm-extrabold text-center text-text-primary">
         게임 만들기
       </h3>
     </Link>

--- a/shared/design/src/components/button/primaryBoxButton.tsx
+++ b/shared/design/src/components/button/primaryBoxButton.tsx
@@ -20,7 +20,7 @@ const primaryBoxButtonVariants = cva(
         solid:
           "bg-background-interactive-primary text-text-interactive-inverse hover:bg-background-interactive-primary-hovered active:bg-background-interactive-primary-pressed",
         outline:
-          "border border-border-interactive-primary text-text-interactive-primary hover:bg-background-interactive-secondary-hovered active:border-0 active:bg-background-interactive-primary-pressed active:text-text-interactive-inverse",
+          "border-2 border-border-interactive-primary text-text-interactive-primary hover:bg-background-interactive-secondary-hovered active:border-0 active:bg-background-interactive-primary-pressed active:text-text-interactive-inverse",
       },
     },
     compoundVariants: [

--- a/shared/design/src/components/button/secondaryOutlineBoxButton.tsx
+++ b/shared/design/src/components/button/secondaryOutlineBoxButton.tsx
@@ -9,8 +9,8 @@ const secondaryOutlineBoxButtonVariants = cva(
   {
     variants: {
       size: {
-        md: "typography-body-lg-semibold h-[48px] w-fit border px-16 py-8",
-        lg: "typography-heading-3xl-semibold h-[98px] w-[572px] border-[3px] px-32 py-20",
+        md: "typography-body-lg-semibold h-[48px] w-fit border-1 px-16 py-8",
+        lg: "typography-heading-3xl-semibold h-[98px] w-[572px] border-2 px-32 py-20",
       },
     },
     defaultVariants: {

--- a/shared/design/src/components/gameCard/index.tsx
+++ b/shared/design/src/components/gameCard/index.tsx
@@ -53,7 +53,7 @@ const GameCardTitle = ({ children, className }: GameCardTitleProps) => {
     <div className="flex h-[46px] w-[178px]">
       <h3
         className={cn(
-          "typography-body-lg-bold line-clamp-2 h-[46px] w-[178px] overflow-hidden text-ellipsis break-keep text-text-primary",
+          "typography-body-lg-extrabold line-clamp-2 h-[46px] w-[178px] overflow-hidden text-ellipsis break-keep text-text-primary",
           className,
         )}
       >

--- a/shared/design/src/plugin/index.ts
+++ b/shared/design/src/plugin/index.ts
@@ -9,6 +9,7 @@ import {
   generateTypographyTokens,
 } from "../tokens/typography"
 import { generateUnitTokens } from "../tokens/unit"
+import { generateWidthTokens } from "../tokens/width"
 
 const {
   base: colorBase,
@@ -18,6 +19,7 @@ const {
 const { theme: typographyTheme } = generateTypographyTokens()
 const { theme: spacingTheme } = generateSpacingTokens()
 const { theme: radiusTheme } = generateRadiusTokens()
+const { theme: widthTheme } = generateWidthTokens()
 const { cssVars: unitCssVars } = generateUnitTokens()
 
 export default plugin(
@@ -50,6 +52,7 @@ export default plugin(
       extend: {
         spacing: spacingTheme,
         borderRadius: radiusTheme,
+        borderWidth: widthTheme,
         colors: colorTheme,
         typography: typographyTheme,
         fontWeight: fontWeightTokens,

--- a/shared/design/src/tokens/variables.json
+++ b/shared/design/src/tokens/variables.json
@@ -3784,13 +3784,13 @@
               }
             },
             {
-              "name": "body/sm/bold",
+              "name": "body/sm/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 11,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": -1,
@@ -3848,13 +3848,13 @@
               }
             },
             {
-              "name": "body/md/bold",
+              "name": "body/md/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 13,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -3912,13 +3912,13 @@
               }
             },
             {
-              "name": "body/lg/bold",
+              "name": "body/lg/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 16,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -3966,7 +3966,7 @@
               "value": {
                 "fontSize": 19,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "SemiBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -3976,13 +3976,13 @@
               }
             },
             {
-              "name": "heading/sm/bold",
+              "name": "heading/sm/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 19,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4040,13 +4040,13 @@
               }
             },
             {
-              "name": "heading/md/bold",
+              "name": "heading/md/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 23,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4104,13 +4104,13 @@
               }
             },
             {
-              "name": "heading/lg/bold",
+              "name": "heading/lg/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 28,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4168,13 +4168,13 @@
               }
             },
             {
-              "name": "heading/xl/bold",
+              "name": "heading/xl/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 33,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4232,13 +4232,13 @@
               }
             },
             {
-              "name": "heading/2xl/bold",
+              "name": "heading/2xl/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 40,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4296,13 +4296,13 @@
               }
             },
             {
-              "name": "heading/3xl/bold",
+              "name": "heading/3xl/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 48,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -4360,13 +4360,13 @@
               }
             },
             {
-              "name": "heading/4xl/bold",
+              "name": "heading/4xl/extrabold",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 57,
                 "fontFamily": "Pretendard",
-                "fontWeight": "Bold",
+                "fontWeight": "ExtraBold",
                 "lineHeight": 120.00000476837158,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,

--- a/shared/design/src/tokens/variables.json
+++ b/shared/design/src/tokens/variables.json
@@ -2297,6 +2297,24 @@
                 "collection": "primitive",
                 "name": "unit/999"
               }
+            },
+            {
+              "name": "border width/border-width-1",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/1"
+              }
+            },
+            {
+              "name": "border width/border-width-2",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "primitive",
+                "name": "unit/2"
+              }
             }
           ]
         },

--- a/shared/design/src/tokens/width.ts
+++ b/shared/design/src/tokens/width.ts
@@ -1,0 +1,33 @@
+import { convertNameToVar } from "./utils"
+import variables from "./variables.json"
+
+const semantic = variables.collections.find((c) => c.name === "semantic")
+
+if (!semantic) {
+  throw new Error("Collection not found")
+}
+
+export const generateWidthTokens = () => {
+  const theme: Record<string, string> = {}
+  const vars = semantic.modes[0]?.variables ?? []
+
+  for (const v of vars) {
+    if (
+      typeof v.name === "string" &&
+      v.name.startsWith("border width/") &&
+      v.type === "number" &&
+      v.isAlias === true &&
+      typeof v.value === "object" &&
+      v.value !== null &&
+      "name" in v.value
+    ) {
+      const key = v.name.split("border-width-")[1]
+      const ref = (v.value as { name: string }).name
+      if (typeof key === "string") {
+        theme[key] = ref.endsWith("/0") ? "0" : convertNameToVar(ref)
+      }
+    }
+  }
+
+  return { theme }
+}


### PR DESCRIPTION
## 📝 설명

- 타이포그래피 토큰에서 bold 계열이 사라지고 extrabold가 생겨서 반영했습니다
- border width도 토큰으로 관리되어 이 부분을 반영했습니다

## 🛠️ 주요 변경 사항

<!--
    commit sha과 함께 변경사항을 위주로 작성하기
    ex)
    - a패키지 설정 변경 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
    - b 페이지 레이아웃 설정 1e9fa6003683cdef34e7fe65d69694a56cafdfb4
 -->

## 리뷰 시 고려해야 할 사항

<!--
    빠른 리뷰를 위해 중점적으로 봐주었으면 하는 사항을 작성
    없으면 생략 가능
 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 앱 전반의 제목 및 본문 글씨 굵기를 Bold에서 ExtraBold로 강화했습니다.
  * 게임 카드, 점수판, 플레이/결과 화면 등 주요 UI 요소 타이포그래피가 일관되게 개선되었습니다.
  * 버튼 윤곽선의 테두리 두께를 일부 크기에서 증가시켰습니다.
* **디자인 시스템**
  * 디자인 토큰에 보더 너비 지원을 추가하여 경계 스타일을 제어할 수 있게 했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->